### PR TITLE
Clean up gRPC manager

### DIFF
--- a/Quickfeed.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Quickfeed.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,88 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "grpc-swift",
+        "repositoryURL": "https://github.com/grpc/grpc-swift",
+        "state": {
+          "branch": null,
+          "revision": "f258d1cd8e8fcc97ebfaaf397e569be3d3fa91d6",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+          "version": "1.4.2"
+        }
+      },
+      {
+        "package": "swift-nio",
+        "repositoryURL": "https://github.com/apple/swift-nio.git",
+        "state": {
+          "branch": null,
+          "revision": "d161bf658780b209c185994528e7e24376cf7283",
+          "version": "2.29.0"
+        }
+      },
+      {
+        "package": "swift-nio-extras",
+        "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
+        "state": {
+          "branch": null,
+          "revision": "29e4c0a2b4ceaa26c41fed765835a1d1cfb5aafd",
+          "version": "1.9.1"
+        }
+      },
+      {
+        "package": "swift-nio-http2",
+        "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
+        "state": {
+          "branch": null,
+          "revision": "e3e9024a632b40695ad5d3a85f9776a9b27a4bc6",
+          "version": "1.17.0"
+        }
+      },
+      {
+        "package": "swift-nio-ssl",
+        "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
+        "state": {
+          "branch": null,
+          "revision": "6363cdf6d2fb863e82434f3c4618f4e896e37569",
+          "version": "2.13.1"
+        }
+      },
+      {
+        "package": "swift-nio-transport-services",
+        "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
+        "state": {
+          "branch": null,
+          "revision": "657537c2cf1845f8d5201ecc4e48f21f21841128",
+          "version": "1.10.0"
+        }
+      },
+      {
+        "package": "SwiftProtobuf",
+        "repositoryURL": "https://github.com/apple/swift-protobuf.git",
+        "state": {
+          "branch": null,
+          "revision": "1f62db409f2c9b0223a3f68567b4a01333aae778",
+          "version": "1.17.0"
+        }
+      },
+      {
+        "package": "SwiftUIX",
+        "repositoryURL": "https://github.com/SwiftUIX/SwiftUIX",
+        "state": {
+          "branch": null,
+          "revision": "5837e88eca8e05fa70c82c6aaecfc59bf7e81bfd",
+          "version": "0.0.7"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Quickfeed/Managers/GRPCManager.swift
+++ b/Quickfeed/Managers/GRPCManager.swift
@@ -339,6 +339,56 @@ class GRPCManager {
         return false
     }
     
+    // MARK: Enrollments
+//    func getEnrollmentsByUser(userID: UInt64, userStatus: [Enrollment.UserStatus]) -> [Enrollment]?{
+//        var request = EnrollmentStatusRequest()
+//        request.userID = userID
+//        request.statuses = userStatus
+//
+//        let call = self.quickfeedClient.getEnrollmentsByUser(request, callOptions: self.defaultOptions)
+//
+//        do {
+//            let response = try call.response.wait()
+//            return response.enrollments
+//        } catch {
+//            print("Call failed: \(error)")
+//        }
+//        return nil
+//    }
+    
+//    func getEnrollmentsByCourse(courseID: UInt64, ignoreGroupMembers: Bool, withActivity: Bool, userStatus: [Enrollment.UserStatus]) -> [Enrollment]?{
+//        var request = EnrollmentRequest()
+//        request.courseID = courseID
+//        request.ignoreGroupMembers = ignoreGroupMembers
+//        request.withActivity = withActivity
+//        request.statuses = userStatus
+//
+//        let call = self.quickfeedClient.getEnrollmentsByCourse(request, callOptions: self.defaultOptions)
+//
+//        do {
+//            let response = try call.response.wait()
+//            return response.enrollments
+//        } catch {
+//            print("Call failed: \(error)")
+//        }
+//        return nil
+//    }
+    
+//    func createEnrollment(enrollment: Enrollment){
+//        let _ = self.quickfeedClient.createEnrollment(enrollment, callOptions: self.defaultOptions)
+//    }
+    
+    func updateEnrollment(enrollment: Enrollment){
+        let _ = self.quickfeedClient.updateEnrollment(enrollment, callOptions: self.defaultOptions)
+    }
+    
+    func updateEnrollments(courseID: UInt64){
+        var request = CourseRequest()
+        request.courseID = courseID
+        
+        let _ = self.quickfeedClient.updateEnrollments(request, callOptions: self.defaultOptions)
+    }
+    
     // TODO: Duplicates with different arguments or returns (see later which one is best to use)
     func getGroupByUserAndCourse(userID: UInt64, courseID: UInt64) -> Group? {
         let req = GroupRequest.with{
@@ -483,48 +533,6 @@ class GRPCManager {
         }
     }
     
-    // TODO: clean up the rest of the gRPC methods
-    func setUser(userID: UInt64){
-        self.userID = userID
-        let headers: HPACKHeaders = ["custom-header-1": "value1", "user": "\(self.userID!)"]
-        self.defaultOptions = CallOptions()
-        self.defaultOptions!.customMetadata = headers
-    }
-    
-    func getProviders(){
-        let call = self.quickfeedClient.getProviders(Void())
-        
-        do {
-            print("Get providers")
-            
-            print("connectivity state: \(self.connection.connectivity.state)")
-            let response = try call.response.wait()
-            
-            
-            print("Call received: \(response.providers)")
-        } catch {
-            print("Call failed: \(error)")
-        }
-    }
-    
-    func updateEnrollment(enrollment: Enrollment){
-        let call = self.quickfeedClient.updateEnrollment(enrollment, callOptions: self.defaultOptions)
-        do {
-            _ = try call.response.wait()
-        } catch {
-            print("Updating enrollment failed: \(error)")
-        }
-    }
-    
-    func createEnrollment(courseID: UInt64, userID: UInt64) {
-        var enrollment = Enrollment()
-        enrollment.courseID = courseID
-        enrollment.userID = userID
-        
-        _ = self.quickfeedClient.createEnrollment(enrollment, callOptions: self.defaultOptions)
-    }
-    
-    
     func getEnrollmentsByUser(userID: UInt64) -> [Enrollment] {
         let req = EnrollmentStatusRequest.with{
             $0.userID = userID
@@ -558,6 +566,38 @@ class GRPCManager {
         
         return call.response
         
+    }
+    
+    func createEnrollment(courseID: UInt64, userID: UInt64) {
+        var enrollment = Enrollment()
+        enrollment.courseID = courseID
+        enrollment.userID = userID
+        
+        _ = self.quickfeedClient.createEnrollment(enrollment, callOptions: self.defaultOptions)
+    }
+    
+    // TODO: clean up the rest of the gRPC methods
+    func setUser(userID: UInt64){
+        self.userID = userID
+        let headers: HPACKHeaders = ["custom-header-1": "value1", "user": "\(self.userID!)"]
+        self.defaultOptions = CallOptions()
+        self.defaultOptions!.customMetadata = headers
+    }
+    
+    func getProviders(){
+        let call = self.quickfeedClient.getProviders(Void())
+        
+        do {
+            print("Get providers")
+            
+            print("connectivity state: \(self.connection.connectivity.state)")
+            let response = try call.response.wait()
+            
+            
+            print("Call received: \(response.providers)")
+        } catch {
+            print("Call failed: \(error)")
+        }
     }
     
     

--- a/Quickfeed/Managers/GRPCManager.swift
+++ b/Quickfeed/Managers/GRPCManager.swift
@@ -393,6 +393,104 @@ class GRPCManager {
         return false
     }
     
+    // MARK: Manual Grading
+    func createBenchmark(gradingBenchmark: GradingBenchmark) -> GradingBenchmark? {
+        let call = self.quickfeedClient.createBenchmark(gradingBenchmark, callOptions: self.defaultOptions)
+        
+        do {
+            let response = try call.response.wait()
+            return response
+        } catch {
+            print("Call failed: \(error)")
+        }
+        return nil
+    }
+    
+    func updateBenchmark(gradingBenchmark: GradingBenchmark) {
+        let _ = self.quickfeedClient.updateBenchmark(gradingBenchmark, callOptions: self.defaultOptions)
+    }
+    
+    func deleteBenchmark(gradingBenchmark: GradingBenchmark) {
+        let _ = self.quickfeedClient.deleteBenchmark(gradingBenchmark, callOptions: self.defaultOptions)
+    }
+    
+    func createCriterion(gradingCriterion: GradingCriterion) -> GradingCriterion? {
+        let call = self.quickfeedClient.createCriterion(gradingCriterion, callOptions: self.defaultOptions)
+        
+        do {
+            let response = try call.response.wait()
+            return response
+        } catch {
+            print("Call failed: \(error)")
+        }
+        return nil
+    }
+    
+    func updateCriterion(gradingCriterion: GradingCriterion) {
+        let _ = self.quickfeedClient.updateCriterion(gradingCriterion, callOptions: self.defaultOptions)
+    }
+    
+    func deleteCriterion(gradingCriterion: GradingCriterion) {
+        let _ = self.quickfeedClient.deleteCriterion(gradingCriterion, callOptions: self.defaultOptions)
+    }
+    
+    func createReview(courseID: UInt64, review: Review) -> Review?{
+        var request = ReviewRequest()
+        request.courseID = courseID
+        request.review = review
+        
+        let call = self.quickfeedClient.createReview(request, callOptions: self.defaultOptions)
+        
+        do {
+            let response = try call.response.wait()
+            return response
+        } catch {
+            print("Call failed: \(error)")
+        }
+        return nil
+    }
+    
+    func updateReview(courseID: UInt64, review: Review) {
+        var request = ReviewRequest()
+        request.courseID = courseID
+        request.review = review
+        
+        let _ = self.quickfeedClient.updateReview(request, callOptions: self.defaultOptions)
+    }
+    
+    func getReviewers(submissionID: UInt64, courseID: UInt64) -> Reviewers?{
+        var request = SubmissionReviewersRequest()
+        request.submissionID = submissionID
+        request.courseID = courseID
+        
+        let call = self.quickfeedClient.getReviewers(request, callOptions: self.defaultOptions)
+        
+        do {
+            let response = try call.response.wait()
+            return response
+        } catch {
+            print("Call failed: \(error)")
+        }
+        return nil
+    }
+    
+    func loadCriteria(courseID: UInt64, assignmentID: UInt64) -> [GradingBenchmark]?{
+        var request = LoadCriteriaRequest()
+        request.courseID = courseID
+        request.assignmentID = assignmentID
+        
+        let call = self.quickfeedClient.loadCriteria(request, callOptions: self.defaultOptions)
+        
+        do {
+            let response = try call.response.wait()
+            return response.benchmarks
+        } catch {
+            print("Call failed: \(error)")
+        }
+        
+        return nil
+    }
+    
     // MARK: Misc
     func getProviders() -> [String]?{
         let call = self.quickfeedClient.getProviders(Void(), callOptions: self.defaultOptions)
@@ -438,76 +536,5 @@ class GRPCManager {
         request.courseID = courseID
         
         let _ = self.quickfeedClient.isEmptyRepo(request, callOptions: self.defaultOptions)
-    }
-    
-    // TODO: clean up the rest of the gRPC methods for manual grading
-    func createReview(courseId: UInt64, review: Review) -> Review?{
-        let req = ReviewRequest.with{
-            $0.courseID = courseId
-            $0.review = review
-        }
-        
-        let call = self.quickfeedClient.createReview(req, callOptions: self.defaultOptions)
-        do {
-            let resp = try call.response.wait()
-            return resp
-        } catch {
-            print("Call failed: \(error)")
-        }
-        
-        return nil
-        
-    }
-    
-    func updateReview(courseId: UInt64, review: Review){
-        let req = ReviewRequest.with{
-            $0.courseID = courseId
-            $0.review = review
-        }
-        
-        let call = self.quickfeedClient.updateReview(req, callOptions: defaultOptions)
-        
-        do {
-            _ = try call.response.wait()
-            return
-        } catch {
-            print("Call failed: \(error)")
-        }
-        
-        
-    }
-    
-    func getReviewers(submissionId: UInt64, courseId: UInt64) -> Reviewers?{
-        let req = SubmissionReviewersRequest.with{
-            $0.courseID = courseId
-            $0.submissionID  = submissionId
-        }
-        
-        let call = self.quickfeedClient.getReviewers(req, callOptions: self.defaultOptions)
-        do {
-            let resp = try call.response.wait()
-            return resp
-        } catch {
-            print("Call failed: \(error)")
-        }
-        return nil
-    }
-    
-    func loadCriteria(courseId: UInt64, assignmentId: UInt64) -> [GradingBenchmark]{
-        let req = LoadCriteriaRequest.with{
-            $0.courseID = courseId
-            $0.assignmentID = assignmentId
-        }
-        
-        let call = self.quickfeedClient.loadCriteria(req, callOptions: self.defaultOptions)
-        
-        do {
-            let resp = try call.response.wait()
-            return resp.benchmarks
-        } catch {
-            print("Call failed: \(error)")
-        }
-        
-        return []
     }
 }

--- a/Quickfeed/Managers/GRPCManager.swift
+++ b/Quickfeed/Managers/GRPCManager.swift
@@ -40,6 +40,14 @@ class GRPCManager {
         try! self.eventLoopGroup.syncShutdownGracefully()
     }
     
+    //TODO: Change name ("createHeader")
+    func setUser(userID: UInt64){
+        self.userID = userID
+        let headers: HPACKHeaders = ["custom-header-1": "value1", "user": "\(self.userID!)"]
+        self.defaultOptions = CallOptions()
+        self.defaultOptions!.customMetadata = headers
+    }
+    
     // MARK: Users
     func getUser() -> User?{
         let call = self.quickfeedClient.getUser(Void(), callOptions: self.defaultOptions)
@@ -172,6 +180,56 @@ class GRPCManager {
         request.courseID = courseID
         
         let _ = self.quickfeedClient.deleteGroup(request, callOptions: self.defaultOptions)
+    }
+    
+    // MARK: Enrollments
+//    func getEnrollmentsByUser(userID: UInt64, userStatus: [Enrollment.UserStatus]) -> [Enrollment]?{
+//        var request = EnrollmentStatusRequest()
+//        request.userID = userID
+//        request.statuses = userStatus
+//
+//        let call = self.quickfeedClient.getEnrollmentsByUser(request, callOptions: self.defaultOptions)
+//
+//        do {
+//            let response = try call.response.wait()
+//            return response.enrollments
+//        } catch {
+//            print("Call failed: \(error)")
+//        }
+//        return nil
+//    }
+    
+//    func getEnrollmentsByCourse(courseID: UInt64, ignoreGroupMembers: Bool, withActivity: Bool, userStatus: [Enrollment.UserStatus]) -> [Enrollment]?{
+//        var request = EnrollmentRequest()
+//        request.courseID = courseID
+//        request.ignoreGroupMembers = ignoreGroupMembers
+//        request.withActivity = withActivity
+//        request.statuses = userStatus
+//
+//        let call = self.quickfeedClient.getEnrollmentsByCourse(request, callOptions: self.defaultOptions)
+//
+//        do {
+//            let response = try call.response.wait()
+//            return response.enrollments
+//        } catch {
+//            print("Call failed: \(error)")
+//        }
+//        return nil
+//    }
+    
+//    func createEnrollment(enrollment: Enrollment){
+//        let _ = self.quickfeedClient.createEnrollment(enrollment, callOptions: self.defaultOptions)
+//    }
+    
+    func updateEnrollment(enrollment: Enrollment){
+        let _ = self.quickfeedClient.updateEnrollment(enrollment, callOptions: self.defaultOptions)
+    }
+    
+    func updateEnrollments(courseID: UInt64){
+        var request = CourseRequest()
+        request.courseID = courseID
+        
+        let _ = self.quickfeedClient.updateEnrollments(request, callOptions: self.defaultOptions)
     }
     
     // MARK: Courses
@@ -339,55 +397,59 @@ class GRPCManager {
         return false
     }
     
-    // MARK: Enrollments
-//    func getEnrollmentsByUser(userID: UInt64, userStatus: [Enrollment.UserStatus]) -> [Enrollment]?{
-//        var request = EnrollmentStatusRequest()
-//        request.userID = userID
-//        request.statuses = userStatus
-//
-//        let call = self.quickfeedClient.getEnrollmentsByUser(request, callOptions: self.defaultOptions)
-//
-//        do {
-//            let response = try call.response.wait()
-//            return response.enrollments
-//        } catch {
-//            print("Call failed: \(error)")
-//        }
-//        return nil
-//    }
-    
-//    func getEnrollmentsByCourse(courseID: UInt64, ignoreGroupMembers: Bool, withActivity: Bool, userStatus: [Enrollment.UserStatus]) -> [Enrollment]?{
-//        var request = EnrollmentRequest()
-//        request.courseID = courseID
-//        request.ignoreGroupMembers = ignoreGroupMembers
-//        request.withActivity = withActivity
-//        request.statuses = userStatus
-//
-//        let call = self.quickfeedClient.getEnrollmentsByCourse(request, callOptions: self.defaultOptions)
-//
-//        do {
-//            let response = try call.response.wait()
-//            return response.enrollments
-//        } catch {
-//            print("Call failed: \(error)")
-//        }
-//        return nil
-//    }
-    
-//    func createEnrollment(enrollment: Enrollment){
-//        let _ = self.quickfeedClient.createEnrollment(enrollment, callOptions: self.defaultOptions)
-//    }
-    
-    func updateEnrollment(enrollment: Enrollment){
-        let _ = self.quickfeedClient.updateEnrollment(enrollment, callOptions: self.defaultOptions)
+    // MARK: Misc
+    func getProviders() -> [String]?{
+        let call = self.quickfeedClient.getProviders(Void(), callOptions: self.defaultOptions)
+        
+        do {
+            let response = try call.response.wait()
+            return response.providers
+        } catch {
+            print("Call failed: \(error)")
+        }
+        return nil
     }
     
-    func updateEnrollments(courseID: UInt64){
-        var request = CourseRequest()
+//    func getOrganization(orgName: String) -> Organization?{
+//        var request = OrgRequest()
+//        request.orgName = orgName
+//
+//        let call = self.quickfeedClient.getOrganization(request, callOptions: self.defaultOptions)
+//
+//        do {
+//            let response = try call.response.wait()
+//            return response
+//        } catch {
+//            print("Call failed: \(error)")
+//        }
+//        return nil
+//    }
+    
+    func getRepositories(courseID: UInt64, repositoryTypes: [Repository.TypeEnum]) -> Repositories?{
+        var request = URLRequest()
+        request.courseID = courseID
+        request.repoTypes = repositoryTypes
+        
+        let call = self.quickfeedClient.getRepositories(request, callOptions: self.defaultOptions)
+        
+        do {
+            let response = try call.response.wait()
+            return response
+        } catch {
+            print("Call failed: \(error)")
+        }
+        return nil
+    }
+    
+    func isEmptyRepo(userID: UInt64, groupID: UInt64, courseID: UInt64){
+        var request = RepositoryRequest()
+        request.userID = userID
+        request.groupID = groupID
         request.courseID = courseID
         
-        let _ = self.quickfeedClient.updateEnrollments(request, callOptions: self.defaultOptions)
+        let _ = self.quickfeedClient.isEmptyRepo(request, callOptions: self.defaultOptions)
     }
+
     
     // TODO: Duplicates with different arguments or returns (see later which one is best to use)
     func getGroupByUserAndCourse(userID: UInt64, courseID: UInt64) -> Group? {
@@ -576,34 +638,16 @@ class GRPCManager {
         _ = self.quickfeedClient.createEnrollment(enrollment, callOptions: self.defaultOptions)
     }
     
-    // TODO: clean up the rest of the gRPC methods
-    func setUser(userID: UInt64){
-        self.userID = userID
-        let headers: HPACKHeaders = ["custom-header-1": "value1", "user": "\(self.userID!)"]
-        self.defaultOptions = CallOptions()
-        self.defaultOptions!.customMetadata = headers
-    }
-    
-    func getProviders(){
-        let call = self.quickfeedClient.getProviders(Void())
+    func getOrganization(orgName: String) -> EventLoopFuture<Organization> {
+        var orgRequest = OrgRequest()
+        orgRequest.orgName = orgName
         
-        do {
-            print("Get providers")
-            
-            print("connectivity state: \(self.connection.connectivity.state)")
-            let response = try call.response.wait()
-            
-            
-            print("Call received: \(response.providers)")
-        } catch {
-            print("Call failed: \(error)")
-        }
+        let call = self.quickfeedClient.getOrganization(orgRequest, callOptions: self.defaultOptions)
+        
+        return call.response
     }
     
-    
-    // MANUAL GRADING
-    
-    
+    // TODO: clean up the rest of the gRPC methods for manual grading
     func createReview(courseId: UInt64, review: Review) -> Review?{
         let req = ReviewRequest.with{
             $0.courseID = courseId
@@ -672,14 +716,5 @@ class GRPCManager {
         }
         
         return []
-    }
-    
-    func getOrganization(orgName: String) -> EventLoopFuture<Organization> {
-        var orgRequest = OrgRequest()
-        orgRequest.orgName = orgName
-        
-        let call = self.quickfeedClient.getOrganization(orgRequest, callOptions: self.defaultOptions)
-        
-        return call.response
     }
 }

--- a/Quickfeed/Managers/GRPCManager.swift
+++ b/Quickfeed/Managers/GRPCManager.swift
@@ -114,52 +114,52 @@ class GRPCManager {
         return nil
     }
     
-    func getGroupByUserAndCourse(userID: UInt64, groupID: UInt64?, courseID: UInt64) -> Group?{
-        var request = GroupRequest()
-        request.userID = userID
-        request.courseID = courseID
-        
-        if groupID != nil{
-            request.groupID = groupID!
-        }
-        
-        let call = self.quickfeedClient.getGroupByUserAndCourse(request, callOptions: self.defaultOptions)
-        
-        do {
-            let response = try call.response.wait()
-            return response
-        } catch {
-            print("Call failed: \(error)")
-        }
-        return nil
-    }
+//    func getGroupByUserAndCourse(userID: UInt64, groupID: UInt64?, courseID: UInt64) -> Group?{
+//        var request = GroupRequest()
+//        request.userID = userID
+//        request.courseID = courseID
+//
+//        if groupID != nil{
+//            request.groupID = groupID!
+//        }
+//
+//        let call = self.quickfeedClient.getGroupByUserAndCourse(request, callOptions: self.defaultOptions)
+//
+//        do {
+//            let response = try call.response.wait()
+//            return response
+//        } catch {
+//            print("Call failed: \(error)")
+//        }
+//        return nil
+//    }
     
-    func getGroupsByCourse(courseID: UInt64) -> [Group]?{
-        var request = CourseRequest()
-        request.courseID = courseID
-        
-        let call = self.quickfeedClient.getGroupsByCourse(request, callOptions: self.defaultOptions)
-        
-        do {
-            let response = try call.response.wait()
-            return response.groups
-        } catch {
-            print("Call failed: \(error)")
-        }
-        return nil
-    }
+//    func getGroupsByCourse(courseID: UInt64) -> [Group]?{
+//        var request = CourseRequest()
+//        request.courseID = courseID
+//
+//        let call = self.quickfeedClient.getGroupsByCourse(request, callOptions: self.defaultOptions)
+//
+//        do {
+//            let response = try call.response.wait()
+//            return response.groups
+//        } catch {
+//            print("Call failed: \(error)")
+//        }
+//        return nil
+//    }
     
-    func createGroup(group: Group) -> Bool{
-        let call = self.quickfeedClient.createGroup(group, callOptions: self.defaultOptions)
-        
-        do {
-            let _ = try call.response.wait()
-            return true
-        } catch {
-            print("Call failed: \(error)")
-        }
-        return false
-    }
+//    func createGroup(group: Group) -> Bool{
+//        let call = self.quickfeedClient.createGroup(group, callOptions: self.defaultOptions)
+//
+//        do {
+//            let _ = try call.response.wait()
+//            return true
+//        } catch {
+//            print("Call failed: \(error)")
+//        }
+//        return false
+//    }
     
     func updateGroup(group: Group){
         let _ = self.quickfeedClient.updateGroup(group, callOptions: self.defaultOptions)
@@ -174,7 +174,71 @@ class GRPCManager {
         let _ = self.quickfeedClient.deleteGroup(request, callOptions: self.defaultOptions)
     }
     
-    // TODO: Duplicates with different arguments or returns
+    // MARK: Courses
+    func getCourse(courseID: UInt64) -> Course?{
+        var request = CourseRequest()
+        request.courseID = courseID
+        
+        let call = self.quickfeedClient.getCourse(request, callOptions: self.defaultOptions)
+        
+        do {
+            let response = try call.response.wait()
+            return response
+        } catch {
+            print("Call failed: \(error)")
+        }
+        return nil
+    }
+    
+    func getCourses() -> [Course]?{
+        let call = self.quickfeedClient.getCourses(Void(), callOptions: self.defaultOptions)
+        
+        do {
+            let response = try call.response.wait()
+            return response.courses
+        } catch {
+            print("Call failed: \(error)")
+        }
+        return nil
+    }
+    
+    func getCoursesByUser(userID: UInt64, userStatus: [Enrollment.UserStatus]) -> [Course]?{
+        var request = EnrollmentStatusRequest()
+        request.userID = userID
+        request.statuses = userStatus
+        
+        let call = self.quickfeedClient.getCoursesByUser(request, callOptions: self.defaultOptions)
+        
+        do {
+            let response = try call.response.wait()
+            return response.courses
+        } catch {
+            print("Call failed: \(error)")
+        }
+        return nil
+    }
+    
+//    func createCourse(course: Course) -> Bool{
+//        let call = self.quickfeedClient.createCourse(course, callOptions: self.defaultOptions)
+//        
+//        do {
+//            let _ = try call.response.wait()
+//            return true
+//        } catch {
+//            print("Call failed: \(error)")
+//        }
+//        return false
+//    }
+    
+    func updateCourse(course: Course){
+        let _ = self.quickfeedClient.updateCourse(course, callOptions: self.defaultOptions)
+    }
+    
+    func updateCourseVisibility(enrollment: Enrollment){
+        let _ = self.quickfeedClient.updateCourseVisibility(enrollment, callOptions: self.defaultOptions)
+    }
+    
+    // TODO: Duplicates with different arguments or returns (see later which one is best to use)
     func getGroupByUserAndCourse(userID: UInt64, courseID: UInt64) -> Group? {
         let req = GroupRequest.with{
             $0.courseID = courseID
@@ -210,6 +274,37 @@ class GRPCManager {
         return call.response
     }
     
+    func getCoursesForCurrentUser() -> [Course]{
+        let req = EnrollmentStatusRequest.with{
+            $0.statuses = [Enrollment.UserStatus.teacher, Enrollment.UserStatus.student]
+            $0.userID = self.userID!
+        }
+        
+        let unaryCall = self.quickfeedClient.getCoursesByUser(req, callOptions: self.defaultOptions)
+        
+        do {
+            let response = try unaryCall.response.wait()
+            
+            return response.courses
+        } catch {
+            print("Call failed: \(error)")
+        }
+        
+        return []
+    }
+    
+    func createCourse(course: Course) -> Course?{
+        let call = self.quickfeedClient.createCourse(course, callOptions: self.defaultOptions)
+        
+        do {
+            let resp = try call.response.wait()
+            return resp
+        } catch {
+            print("Call failed: \(error)")
+            return nil
+        }
+    }
+    
     // TODO: clean up the rest of the gRPC methods
     func setUser(userID: UInt64){
         self.userID = userID
@@ -234,25 +329,6 @@ class GRPCManager {
         }
     }
     
-    func getCoursesForCurrentUser() -> [Course]{
-        let req = EnrollmentStatusRequest.with{
-            $0.statuses = [Enrollment.UserStatus.teacher, Enrollment.UserStatus.student]
-            $0.userID = self.userID!
-        }
-        
-        let unaryCall = self.quickfeedClient.getCoursesByUser(req, callOptions: self.defaultOptions)
-        
-        do {
-            let response = try unaryCall.response.wait()
-            
-            return response.courses
-        } catch {
-            print("Call failed: \(error)")
-        }
-        
-        return []
-    }
-    
     func updateEnrollment(enrollment: Enrollment){
         let call = self.quickfeedClient.updateEnrollment(enrollment, callOptions: self.defaultOptions)
         do {
@@ -260,35 +336,6 @@ class GRPCManager {
         } catch {
             print("Updating enrollment failed: \(error)")
         }
-    }
-    
-    func getCourse(courseId: UInt64) -> Course? {
-        
-        let req = CourseRequest.with{
-            $0.courseID = courseId
-        }
-        
-        let unaryCall = self.quickfeedClient.getCourse(req, callOptions: self.defaultOptions)
-        
-        do {
-            let response = try unaryCall.response.wait()
-            return response
-        } catch {
-            print("Call failed: \(error)")
-        }
-        
-        return nil
-    }
-    
-    func getCourses() -> [Course]? {
-        let call = self.quickfeedClient.getCourses(Void(), callOptions: self.defaultOptions)
-        do {
-            let response = try call.response.wait()
-            return response.courses
-        } catch {
-            print("Call failed: \(error)")
-        }
-        return nil
     }
     
     func getSubmissionsForEnrollment(courseId: UInt64, userId: UInt64) -> [Submission]{
@@ -520,29 +567,6 @@ class GRPCManager {
         }
         
         return []
-    }
-    
-    // Course
-    func createCourse(course: Course) -> Course?{
-        let call = self.quickfeedClient.createCourse(course, callOptions: self.defaultOptions)
-        
-        do {
-            let resp = try call.response.wait()
-            return resp
-        } catch {
-            print("Call failed: \(error)")
-            return nil
-        }
-    }
-    
-    func updateCourse(course: Course){
-        let call = self.quickfeedClient.updateCourse(course, callOptions: self.defaultOptions)
-        
-        do {
-            _ = try call.response.wait()
-        } catch {
-            print("Call failed: \(error)")
-        }
     }
     
     func getOrganization(orgName: String) -> EventLoopFuture<Organization> {

--- a/Quickfeed/Managers/GRPCManager.swift
+++ b/Quickfeed/Managers/GRPCManager.swift
@@ -15,9 +15,7 @@ class GRPCManager {
     let connection: ClientConnection
     let eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     
-    let headers: HPACKHeaders? = nil
     var defaultOptions: CallOptions?
-    var userID: UInt64?
     
     private init(){
         let hostname = "localhost"
@@ -34,21 +32,22 @@ class GRPCManager {
         print("Connecting to \(hostname)")
     }
     
+    func createHeader(userID: UInt64){
+        self.defaultOptions = CallOptions()
+        self.defaultOptions!.customMetadata = ["custom-header-1": "value1", "user": "\(userID)"]
+    }
+    
     func shutdown() {
         // Close the connections when we're done with it.
         try! self.connection.close().wait()
         try! self.eventLoopGroup.syncShutdownGracefully()
     }
     
-    //TODO: Change name ("createHeader")
+    // MARK: Users
     func setUser(userID: UInt64){
-        self.userID = userID
-        let headers: HPACKHeaders = ["custom-header-1": "value1", "user": "\(self.userID!)"]
-        self.defaultOptions = CallOptions()
-        self.defaultOptions!.customMetadata = headers
+        createHeader(userID: userID)
     }
     
-    // MARK: Users
     func getUser() -> User?{
         let call = self.quickfeedClient.getUser(Void(), callOptions: self.defaultOptions)
         
@@ -122,52 +121,40 @@ class GRPCManager {
         return nil
     }
     
-//    func getGroupByUserAndCourse(userID: UInt64, groupID: UInt64?, courseID: UInt64) -> Group?{
-//        var request = GroupRequest()
-//        request.userID = userID
-//        request.courseID = courseID
-//
-//        if groupID != nil{
-//            request.groupID = groupID!
-//        }
-//
-//        let call = self.quickfeedClient.getGroupByUserAndCourse(request, callOptions: self.defaultOptions)
-//
-//        do {
-//            let response = try call.response.wait()
-//            return response
-//        } catch {
-//            print("Call failed: \(error)")
-//        }
-//        return nil
-//    }
+    func getGroupByUserAndCourse(userID: UInt64, groupID: UInt64?, courseID: UInt64) -> Group?{
+        var request = GroupRequest()
+        request.userID = userID
+        request.courseID = courseID
+
+        if groupID != nil{
+            request.groupID = groupID!
+        }
+
+        let call = self.quickfeedClient.getGroupByUserAndCourse(request, callOptions: self.defaultOptions)
+
+        do {
+            let response = try call.response.wait()
+            return response
+        } catch {
+            print("Call failed: \(error)")
+        }
+        return nil
+    }
     
-//    func getGroupsByCourse(courseID: UInt64) -> [Group]?{
-//        var request = CourseRequest()
-//        request.courseID = courseID
-//
-//        let call = self.quickfeedClient.getGroupsByCourse(request, callOptions: self.defaultOptions)
-//
-//        do {
-//            let response = try call.response.wait()
-//            return response.groups
-//        } catch {
-//            print("Call failed: \(error)")
-//        }
-//        return nil
-//    }
+    func getGroupsByCourse(courseID: UInt64) -> EventLoopFuture<Groups>{
+        var request = CourseRequest()
+        request.courseID = courseID
+
+        let call = self.quickfeedClient.getGroupsByCourse(request, callOptions: self.defaultOptions)
+
+        return call.response
+    }
     
-//    func createGroup(group: Group) -> Bool{
-//        let call = self.quickfeedClient.createGroup(group, callOptions: self.defaultOptions)
-//
-//        do {
-//            let _ = try call.response.wait()
-//            return true
-//        } catch {
-//            print("Call failed: \(error)")
-//        }
-//        return false
-//    }
+    func createGroup(group: Group) -> EventLoopFuture<Group>{
+        let call = self.quickfeedClient.createGroup(group, callOptions: self.defaultOptions)
+
+        return call.response
+    }
     
     func updateGroup(group: Group){
         let _ = self.quickfeedClient.updateGroup(group, callOptions: self.defaultOptions)
@@ -183,43 +170,42 @@ class GRPCManager {
     }
     
     // MARK: Enrollments
-//    func getEnrollmentsByUser(userID: UInt64, userStatus: [Enrollment.UserStatus]) -> [Enrollment]?{
-//        var request = EnrollmentStatusRequest()
-//        request.userID = userID
-//        request.statuses = userStatus
-//
-//        let call = self.quickfeedClient.getEnrollmentsByUser(request, callOptions: self.defaultOptions)
-//
-//        do {
-//            let response = try call.response.wait()
-//            return response.enrollments
-//        } catch {
-//            print("Call failed: \(error)")
-//        }
-//        return nil
-//    }
+    func getEnrollmentsByUser(userID: UInt64, userStatus: [Enrollment.UserStatus]) -> [Enrollment]?{
+        var request = EnrollmentStatusRequest()
+        request.userID = userID
+        request.statuses = userStatus
+
+        let call = self.quickfeedClient.getEnrollmentsByUser(request, callOptions: self.defaultOptions)
+
+        do {
+            let response = try call.response.wait()
+            return response.enrollments
+        } catch {
+            print("Call failed: \(error)")
+        }
+        return nil
+    }
     
-//    func getEnrollmentsByCourse(courseID: UInt64, ignoreGroupMembers: Bool, withActivity: Bool, userStatus: [Enrollment.UserStatus]) -> [Enrollment]?{
-//        var request = EnrollmentRequest()
-//        request.courseID = courseID
-//        request.ignoreGroupMembers = ignoreGroupMembers
-//        request.withActivity = withActivity
-//        request.statuses = userStatus
-//
-//        let call = self.quickfeedClient.getEnrollmentsByCourse(request, callOptions: self.defaultOptions)
-//
-//        do {
-//            let response = try call.response.wait()
-//            return response.enrollments
-//        } catch {
-//            print("Call failed: \(error)")
-//        }
-//        return nil
-//    }
+    func getEnrollmentsByCourse(courseID: UInt64, ignoreGroupMembers: Bool?, withActivity: Bool?, userStatus: [Enrollment.UserStatus]) -> EventLoopFuture<Enrollments>{
+        var request = EnrollmentRequest()
+        request.courseID = courseID
+        request.statuses = userStatus
+        
+        if ignoreGroupMembers != nil {
+            request.ignoreGroupMembers = ignoreGroupMembers!
+        }
+        if withActivity != nil {
+            request.withActivity = withActivity!
+        }
+
+        let call = self.quickfeedClient.getEnrollmentsByCourse(request, callOptions: self.defaultOptions)
+        
+        return call.response
+    }
     
-//    func createEnrollment(enrollment: Enrollment){
-//        let _ = self.quickfeedClient.createEnrollment(enrollment, callOptions: self.defaultOptions)
-//    }
+    func createEnrollment(enrollment: Enrollment){
+        let _ = self.quickfeedClient.createEnrollment(enrollment, callOptions: self.defaultOptions)
+    }
     
     func updateEnrollment(enrollment: Enrollment){
         let _ = self.quickfeedClient.updateEnrollment(enrollment, callOptions: self.defaultOptions)
@@ -276,17 +262,17 @@ class GRPCManager {
         return nil
     }
     
-//    func createCourse(course: Course) -> Bool{
-//        let call = self.quickfeedClient.createCourse(course, callOptions: self.defaultOptions)
-//        
-//        do {
-//            let _ = try call.response.wait()
-//            return true
-//        } catch {
-//            print("Call failed: \(error)")
-//        }
-//        return false
-//    }
+    func createCourse(course: Course) -> Course?{
+        let call = self.quickfeedClient.createCourse(course, callOptions: self.defaultOptions)
+        
+        do {
+            let response = try call.response.wait()
+            return response
+        } catch {
+            print("Call failed: \(error)")
+        }
+        return nil
+    }
     
     func updateCourse(course: Course){
         let _ = self.quickfeedClient.updateCourse(course, callOptions: self.defaultOptions)
@@ -312,12 +298,20 @@ class GRPCManager {
         return nil
     }
     
-//    func updateAssignments(courseID: UInt64){
-//        var request = CourseRequest()
-//        request.courseID = courseID
-//
-//        let _ = self.quickfeedClient.updateAssignments(request, callOptions: self.defaultOptions)
-//    }
+    func updateAssignments(courseID: UInt64) -> Bool{
+        var request = CourseRequest()
+        request.courseID = courseID
+
+        let call = self.quickfeedClient.updateAssignments(request, callOptions: self.defaultOptions)
+        
+        do {
+            let _ = try call.response.wait()
+            return true
+        } catch {
+            print("Call failed: \(error)")
+        }
+        return false
+    }
     
     // MARK: Submissions
     func getSubmissions(userID: UInt64?, groupID: UInt64?, courseID: UInt64) -> [Submission]?{
@@ -343,32 +337,34 @@ class GRPCManager {
         return nil
     }
     
-//    func getSubmissionsByCourse(courseID: UInt64, type: SubmissionsForCourseRequest.TypeEnum) -> CourseSubmissions?{
-//        var request = SubmissionsForCourseRequest()
-//        request.courseID = courseID
-//        request.type = type
-//
-//        let call = self.quickfeedClient.getSubmissionsByCourse(request, callOptions: self.defaultOptions)
-//
-//        do {
-//            let response = try call.response.wait()
-//            return response
-//        } catch {
-//            print("Call failed: \(error)")
-//        }
-//        return nil
-//    }
+    func getSubmissionsByCourse(courseID: UInt64, type: SubmissionsForCourseRequest.TypeEnum) -> EventLoopFuture<CourseSubmissions>{
+        var request = SubmissionsForCourseRequest()
+        request.courseID = courseID
+        request.type = type
+
+        let call = self.quickfeedClient.getSubmissionsByCourse(request, callOptions: self.defaultOptions)
+        
+        return call.response
+    }
     
-//    func updateSubmission(submissionID: UInt64, courseID: UInt64, score: UInt32, released: Bool, status: Submission.Status){
-//        var request = UpdateSubmissionRequest()
-//        request.submissionID = submissionID
-//        request.courseID = courseID
-//        request.score = score
-//        request.released = released
-//        request.status = status
-//
-//        let _ = self.quickfeedClient.updateSubmission(request, callOptions: self.defaultOptions)
-//    }
+    func updateSubmission(submissionID: UInt64, courseID: UInt64, score: UInt32, released: Bool, status: Submission.Status) -> Bool {
+        var request = UpdateSubmissionRequest()
+        request.submissionID = submissionID
+        request.courseID = courseID
+        request.score = score
+        request.released = released
+        request.status = status
+
+        let call = self.quickfeedClient.updateSubmission(request, callOptions: self.defaultOptions)
+        
+        do {
+            _ = try call.response.wait()
+            return true
+        } catch {
+            print("Call failed: \(error)")
+        }
+        return false
+    }
     
     func updateSubmissions(courseID: UInt64, assignmentID: UInt64, scoreLimit: UInt32, release: Bool, approve: Bool){
         var request = UpdateSubmissionsRequest()
@@ -410,20 +406,14 @@ class GRPCManager {
         return nil
     }
     
-//    func getOrganization(orgName: String) -> Organization?{
-//        var request = OrgRequest()
-//        request.orgName = orgName
-//
-//        let call = self.quickfeedClient.getOrganization(request, callOptions: self.defaultOptions)
-//
-//        do {
-//            let response = try call.response.wait()
-//            return response
-//        } catch {
-//            print("Call failed: \(error)")
-//        }
-//        return nil
-//    }
+    func getOrganization(orgName: String) -> EventLoopFuture<Organization>{
+        var request = OrgRequest()
+        request.orgName = orgName
+
+        let call = self.quickfeedClient.getOrganization(request, callOptions: self.defaultOptions)
+        
+        return call.response
+    }
     
     func getRepositories(courseID: UInt64, repositoryTypes: [Repository.TypeEnum]) -> Repositories?{
         var request = URLRequest()
@@ -448,203 +438,6 @@ class GRPCManager {
         request.courseID = courseID
         
         let _ = self.quickfeedClient.isEmptyRepo(request, callOptions: self.defaultOptions)
-    }
-
-    
-    // TODO: Duplicates with different arguments or returns (see later which one is best to use)
-    func getGroupByUserAndCourse(userID: UInt64, courseID: UInt64) -> Group? {
-        let req = GroupRequest.with{
-            $0.courseID = courseID
-            $0.userID = userID
-        }
-        
-        let call = self.quickfeedClient.getGroupByUserAndCourse(req, callOptions: self.defaultOptions)
-        
-        do {
-            let response = try call.response.wait()
-            return response
-        } catch {
-            print("Call failed: \(error)")
-        }
-        
-        return nil
-    }
-    
-    func getGroupsByCourse(courseId: UInt64) -> EventLoopFuture<Groups>{
-        let req = CourseRequest.with{
-            $0.courseID = courseId
-        }
-        
-        let call = self.quickfeedClient.getGroupsByCourse(req, callOptions: self.defaultOptions)
-        
-        return call.response
-    }
-    
-    func createGroup(group: Group) -> EventLoopFuture<Group>{
-        
-        let call = self.quickfeedClient.createGroup(group, callOptions: self.defaultOptions)
-        
-        return call.response
-    }
-    
-    func getCoursesForCurrentUser() -> [Course]{
-        let req = EnrollmentStatusRequest.with{
-            $0.statuses = [Enrollment.UserStatus.teacher, Enrollment.UserStatus.student]
-            $0.userID = self.userID!
-        }
-        
-        let unaryCall = self.quickfeedClient.getCoursesByUser(req, callOptions: self.defaultOptions)
-        
-        do {
-            let response = try unaryCall.response.wait()
-            
-            return response.courses
-        } catch {
-            print("Call failed: \(error)")
-        }
-        
-        return []
-    }
-    
-    func createCourse(course: Course) -> Course?{
-        let call = self.quickfeedClient.createCourse(course, callOptions: self.defaultOptions)
-        
-        do {
-            let resp = try call.response.wait()
-            return resp
-        } catch {
-            print("Call failed: \(error)")
-            return nil
-        }
-    }
-    
-    func updateAssignments(courseId: UInt64) -> Bool{
-        let req = CourseRequest.with{
-            $0.courseID = courseId
-        }
-        
-        let call = self.quickfeedClient.updateAssignments(req, callOptions: self.defaultOptions)
-        
-        do {
-            _ = try call.response.wait()
-            return true
-        } catch {
-            print("Call failed: \(error)")
-            return false
-        }
-    }
-    
-    func getSubbmissionByGroup(courseID: UInt64, groupID: UInt64) -> [Submission] {
-        let req = SubmissionRequest.with{
-            $0.courseID = courseID
-            $0.groupID = groupID
-        }
-        let call = self.quickfeedClient.getSubmissions(req, callOptions: self.defaultOptions)
-        do {
-            let response = try call.response.wait()
-            return response.submissions
-        } catch {
-            print("Call failed: \(error)")
-        }
-        
-        return []
-    }
-    
-    func getSubmissionsForEnrollment(courseId: UInt64, userId: UInt64) -> [Submission]{
-        let req = SubmissionRequest.with{
-            $0.courseID = courseId
-            $0.userID = userId
-        }
-        let call = self.quickfeedClient.getSubmissions(req, callOptions: self.defaultOptions)
-        do {
-            let response = try call.response.wait()
-            return response.submissions
-        } catch {
-            print("Call failed: \(error)")
-        }
-        
-        return []
-        
-    }
-    
-    func getSubmissionsByCourse(courseId: UInt64, type: SubmissionsForCourseRequest.TypeEnum) -> EventLoopFuture<CourseSubmissions>{
-        let req = SubmissionsForCourseRequest.with{
-            $0.courseID = courseId
-            $0.type = type
-        }
-        
-        let call = self.quickfeedClient.getSubmissionsByCourse(req, callOptions: self.defaultOptions)
-        return call.response
-    }
-    
-    func updateSubmission(courseId: UInt64, submission: Submission) -> Bool{
-        let req = UpdateSubmissionRequest.with{
-            $0.courseID = courseId
-            $0.submissionID = submission.id
-            $0.score = submission.score
-            $0.released = submission.released
-            $0.status = submission.status
-        }
-        let call = self.quickfeedClient.updateSubmission(req, callOptions: self.defaultOptions)
-        do {
-            _ = try call.response.wait()
-            return true
-        } catch {
-            print("Call failed: \(error)")
-            return false
-        }
-    }
-    
-    func getEnrollmentsByUser(userID: UInt64) -> [Enrollment] {
-        let req = EnrollmentStatusRequest.with{
-            $0.userID = userID
-        }
-        
-        let call = self.quickfeedClient.getEnrollmentsByUser(req, callOptions: self.defaultOptions)
-        
-        do {
-            let response = try call.response.wait()
-            return response.enrollments
-        } catch {
-            print("Call failed: \(error)")
-        }
-        
-        return []
-    }
-    
-    func getEnrollmentsByCourse(courseId: UInt64, ignoreGroupMembers: Bool?, enrollmentStatus: [Enrollment.UserStatus]?) -> EventLoopFuture<Enrollments>{
-        let req = EnrollmentRequest.with{
-            $0.courseID = courseId
-            $0.withActivity = true
-            if ignoreGroupMembers != nil {
-                $0.ignoreGroupMembers = ignoreGroupMembers!
-            }
-            if enrollmentStatus != nil{
-                $0.statuses = enrollmentStatus!
-            }
-        }
-        
-        let call = self.quickfeedClient.getEnrollmentsByCourse(req, callOptions: self.defaultOptions)
-        
-        return call.response
-        
-    }
-    
-    func createEnrollment(courseID: UInt64, userID: UInt64) {
-        var enrollment = Enrollment()
-        enrollment.courseID = courseID
-        enrollment.userID = userID
-        
-        _ = self.quickfeedClient.createEnrollment(enrollment, callOptions: self.defaultOptions)
-    }
-    
-    func getOrganization(orgName: String) -> EventLoopFuture<Organization> {
-        var orgRequest = OrgRequest()
-        orgRequest.orgName = orgName
-        
-        let call = self.quickfeedClient.getOrganization(orgRequest, callOptions: self.defaultOptions)
-        
-        return call.response
     }
     
     // TODO: clean up the rest of the gRPC methods for manual grading

--- a/Quickfeed/Providers/ProviderProtocol.swift
+++ b/Quickfeed/Providers/ProviderProtocol.swift
@@ -11,7 +11,7 @@ import NIO
 protocol ProviderProtocol{
     func setUser(userID: UInt64)
     func getUser() -> User?
-    func getCoursesForCurrentUser() -> [Course]?
+    func getCoursesForCurrentUser(userID: UInt64, userStatus: [Enrollment.UserStatus]) -> [Course]?
     func isAuthorizedTeacher() -> Bool
     func getCourses() -> [Course]?
     func getUsers() -> [User]?
@@ -27,7 +27,7 @@ protocol ProviderProtocol{
     func createGroup(group: Group) -> EventLoopFuture<Group>
     
     
-    func getGroupByUserAndCourse(courseId: UInt64, userId: UInt64) -> Group?
+    func getGroupByUserAndCourse(courseId: UInt64, groupID: UInt64?, userId: UInt64) -> Group?
     func getGroupsByCourse(courseId: UInt64) -> EventLoopFuture<Groups>
     func getSubmissionsByUser(courseId: UInt64, userId: UInt64) -> [Submission]
     func getSubmissionsByGroub(courseId: UInt64, groupId: UInt64) -> [Submission]
@@ -41,7 +41,7 @@ protocol ProviderProtocol{
     func rebuildSubmission(assignmentId: UInt64, submissionId: UInt64) -> Submission?
     func getRepositories(courseId: UInt64, types: [Repository.Type])
     
-    func getEnrollmentsByCourse(courseId: UInt64, ignoreGroupMembers: Bool?, enrollmentStatus: [Enrollment.UserStatus]?) -> EventLoopFuture<Enrollments>
+    func getEnrollmentsByCourse(courseId: UInt64, ignoreGroupMembers: Bool?, withActivity: Bool?, userStatus: [Enrollment.UserStatus]) -> EventLoopFuture<Enrollments>
     
     func createReview(courseId: UInt64, review: Review) -> Review?
     func getReviewers(submissionId: UInt64, courseId: UInt64) -> Reviewers?

--- a/Quickfeed/Providers/ServerProvider.swift
+++ b/Quickfeed/Providers/ServerProvider.swift
@@ -27,8 +27,8 @@ class ServerProvider: ProviderProtocol{
         grpcManager.updateUser(user: user)
     }
     
-    func getCoursesForCurrentUser() -> [Course]? {
-        return grpcManager.getCoursesForCurrentUser()
+    func getCoursesForCurrentUser(userID: UInt64, userStatus: [Enrollment.UserStatus]) -> [Course]? {
+        return grpcManager.getCoursesByUser(userID: userID, userStatus: userStatus)
     }
     
     func getOrganization(orgName: String) -> EventLoopFuture<Organization> {
@@ -59,17 +59,21 @@ class ServerProvider: ProviderProtocol{
         return []
     }
     func updateAssignments(courseId: UInt64) -> Bool {
-        return self.grpcManager.updateAssignments(courseId: courseId)
+        return self.grpcManager.updateAssignments(courseID: courseId)
     }
     
     // ENROLLMENTS
     
     func createEnrollment(courseID: UInt64, userID: UInt64) {
-        self.grpcManager.createEnrollment(courseID: courseID, userID: userID)
+        var enrollment = Enrollment()
+        enrollment.courseID = courseID
+        enrollment.userID = userID
+        
+        self.grpcManager.createEnrollment(enrollment: enrollment)
     }
     
     func getEnrollmentsForUser(userId: UInt64) -> [Enrollment] {
-        return self.grpcManager.getEnrollmentsByUser(userID: userId)
+        return self.grpcManager.getEnrollmentsByUser(userID: userId, userStatus: [Enrollment.UserStatus.teacher, Enrollment.UserStatus.student, Enrollment.UserStatus.pending])!
     }
     
     func updateEnrollment(enrollment: Enrollment, status: Enrollment.UserStatus) {
@@ -78,9 +82,8 @@ class ServerProvider: ProviderProtocol{
         grpcManager.updateEnrollment(enrollment: enrollment)
     }
 
-    func getEnrollmentsByCourse(courseId: UInt64, ignoreGroupMembers: Bool?, enrollmentStatus: [Enrollment.UserStatus]?) -> EventLoopFuture<Enrollments>{
-        return self.grpcManager.getEnrollmentsByCourse(courseId: courseId, ignoreGroupMembers: ignoreGroupMembers, enrollmentStatus: enrollmentStatus)
-        
+    func getEnrollmentsByCourse(courseId: UInt64, ignoreGroupMembers: Bool?, withActivity: Bool?, userStatus: [Enrollment.UserStatus]) -> EventLoopFuture<Enrollments>{
+        return self.grpcManager.getEnrollmentsByCourse(courseID: courseId, ignoreGroupMembers: ignoreGroupMembers, withActivity: withActivity, userStatus: userStatus)
     }
     
     // GROUPS
@@ -92,31 +95,33 @@ class ServerProvider: ProviderProtocol{
         self.grpcManager.updateGroup(group: group)
     }
     
-    func getGroupByUserAndCourse(courseId: UInt64, userId: UInt64) -> Group? {
-        return self.grpcManager.getGroupByUserAndCourse(userID: userId, courseID: courseId)
+    func getGroupByUserAndCourse(courseId: UInt64, groupID: UInt64?, userId: UInt64) -> Group? {
+        return self.grpcManager.getGroupByUserAndCourse(userID: userId, groupID: groupID, courseID: courseId)
     }
     
     func getGroupsByCourse(courseId: UInt64) -> EventLoopFuture<Groups> {
-        return self.grpcManager.getGroupsByCourse(courseId: courseId)
+        return self.grpcManager.getGroupsByCourse(courseID: courseId)
     }
     
     
     // SUBMISSIONS
     func getSubmissionsByUser(courseId: UInt64, userId: UInt64) -> [Submission] {
-        let submissions = self.grpcManager.getSubmissionsForEnrollment(courseId: courseId, userId: userId)
-        return submissions
+        /*let submissions = self.grpcManager.getSubmissionsForEnrollment(courseId: courseId, userId: userId)
+        return submissions*/
+        return self.grpcManager.getSubmissions(userID: userId, groupID: nil, courseID: courseId)!
     }
     
     func getSubmissionsByGroub(courseId: UInt64, groupId: UInt64) -> [Submission] {
-        return self.grpcManager.getSubbmissionByGroup(courseID: courseId, groupID: groupId)
+        return self.grpcManager.getSubmissions(userID: nil, groupID: groupId, courseID: courseId)!
+        //return self.grpcManager.getSubbmissionByGroup(courseID: courseId, groupID: groupId)
     }
     
     func getSubmissionsByCourse(courseId: UInt64, type: SubmissionsForCourseRequest.TypeEnum) -> EventLoopFuture<CourseSubmissions> {
-        return self.grpcManager.getSubmissionsByCourse(courseId: courseId, type: type)
+        return self.grpcManager.getSubmissionsByCourse(courseID: courseId, type: type)
     }
     
     func updateSubmission(courseId: UInt64, submisssion: Submission) -> Bool {
-        return self.grpcManager.updateSubmission(courseId: courseId, submission: submisssion)
+        return self.grpcManager.updateSubmission(submissionID: submisssion.id, courseID: courseId, score: submisssion.score, released: submisssion.released, status: submisssion.status)
     }
     
     func updateSubmissions(assignmentID: UInt64, courseID: UInt64, score: UInt32, release: Bool, approve: Bool) {

--- a/Quickfeed/Providers/ServerProvider.swift
+++ b/Quickfeed/Providers/ServerProvider.swift
@@ -131,19 +131,19 @@ class ServerProvider: ProviderProtocol{
     
     // MANUAL GRADING
     func loadCriteria(courseId: UInt64, assignmentId: UInt64) -> [GradingBenchmark] {
-        return self.grpcManager.loadCriteria(courseId: courseId, assignmentId: assignmentId)
+        return self.grpcManager.loadCriteria(courseID: courseId, assignmentID: assignmentId)!
     }
     
     func createReview(courseId: UInt64, review: Review) -> Review?{
-        return self.grpcManager.createReview(courseId: courseId, review: review)
+        return self.grpcManager.createReview(courseID: courseId, review: review)
     }
     
     func updateReview(courseId: UInt64, review: Review){
-        return self.grpcManager.updateReview(courseId: courseId, review: review)
+        return self.grpcManager.updateReview(courseID: courseId, review: review)
     }
     
     func getReviewers(submissionId: UInt64, courseId: UInt64) -> Reviewers?{
-        return self.grpcManager.getReviewers(submissionId: submissionId, courseId: courseId)
+        return self.grpcManager.getReviewers(submissionID: submissionId, courseID: courseId)
     }
     
     // Courses

--- a/Quickfeed/Providers/ServerProvider.swift
+++ b/Quickfeed/Providers/ServerProvider.swift
@@ -52,7 +52,11 @@ class ServerProvider: ProviderProtocol{
     }
     
     func getAssignments(courseID: UInt64) -> [Assignment] {
-        return self.grpcManager.getAssignments(courseId: courseID)
+        let assignments = self.grpcManager.getAssignments(courseID: courseID)
+        if assignments != nil {
+            return assignments!
+        }
+        return []
     }
     func updateAssignments(courseId: UInt64) -> Bool {
         return self.grpcManager.updateAssignments(courseId: courseId)
@@ -116,7 +120,7 @@ class ServerProvider: ProviderProtocol{
     }
     
     func updateSubmissions(assignmentID: UInt64, courseID: UInt64, score: UInt32, release: Bool, approve: Bool) {
-        grpcManager.updateSubmissions(assignmentID: assignmentID, courseID: courseID, score: score, release: release, approve: approve)
+        grpcManager.updateSubmissions(courseID: courseID, assignmentID: assignmentID, scoreLimit: score, release: release, approve: approve)
     }
     
     

--- a/Quickfeed/Providers/ServerProvider.swift
+++ b/Quickfeed/Providers/ServerProvider.swift
@@ -48,7 +48,7 @@ class ServerProvider: ProviderProtocol{
     }
 
     func getCourse(courseId: UInt64) -> Course? {
-        return self.grpcManager.getCourse(courseId: courseId)
+        return self.grpcManager.getCourse(courseID: courseId)
     }
     
     func getAssignments(courseID: UInt64) -> [Assignment] {

--- a/Quickfeed/ViewModels/StudentViewModel.swift
+++ b/Quickfeed/ViewModels/StudentViewModel.swift
@@ -22,7 +22,7 @@ class StudentViewModel: UserViewModelProtocol{
     
     func setCourse(course: Course){
         self.course = course
-        self.group = provider.getGroupByUserAndCourse(courseId: course.id, userId: user.id)
+        self.group = provider.getGroupByUserAndCourse(courseId: course.id, groupID: nil, userId: user.id)
     }
     
     func createGroup(name: String, enrollments: [Enrollment]) {
@@ -64,7 +64,7 @@ class StudentViewModel: UserViewModelProtocol{
     }
     
     func getEnrollmentsByCourse() {
-        let response = self.provider.getEnrollmentsByCourse(courseId: self.course!.id, ignoreGroupMembers: true, enrollmentStatus: [Enrollment.UserStatus.student])
+        let response = self.provider.getEnrollmentsByCourse(courseId: self.course!.id, ignoreGroupMembers: true, withActivity: nil, userStatus: [Enrollment.UserStatus.student])
         _ = response.always {(response: Result<Enrollments, Error>) in
             switch response {
             case .success(let response):

--- a/Quickfeed/ViewModels/TeacherViewModel.swift
+++ b/Quickfeed/ViewModels/TeacherViewModel.swift
@@ -84,7 +84,7 @@ class TeacherViewModel: UserViewModelProtocol{
     }
     
     func loadEnrollments(){
-        let response = self.provider.getEnrollmentsByCourse(courseId: self.currentCourse.id, ignoreGroupMembers: nil, enrollmentStatus: nil)
+        let response = self.provider.getEnrollmentsByCourse(courseId: self.currentCourse.id, ignoreGroupMembers: nil, withActivity: nil, userStatus: [Enrollment.UserStatus.student, Enrollment.UserStatus.teacher, Enrollment.UserStatus.pending])
         _ = response.always {(response: Result<Enrollments, Error>) in
             switch response {
             case .success(let response):

--- a/Quickfeed/ViewModels/UserViewModel.swift
+++ b/Quickfeed/ViewModels/UserViewModel.swift
@@ -58,7 +58,7 @@ class UserViewModel: UserViewModelProtocol {
     }
     
     func getAllCoursesForCurrentUser() {
-        self.courses = self.provider.getCoursesForCurrentUser()
+        self.courses = self.provider.getCoursesForCurrentUser(userID: self.user!.id, userStatus: [Enrollment.UserStatus.student, Enrollment.UserStatus.teacher])
     }
     
     func isTeacherForCourse(courseId: UInt64) -> Bool? {


### PR DESCRIPTION
This PR does the following with the gRPC manager, Closes #73 
- Deleted duplicate methods
- Merges multiple methods that can be done in one gRPC method
- Divided the gRPC methods into clear categories with MARK: commands (same categories as the rpc services in ag.proto)