### PR TITLE
Reorganized viewmodels (Student, admin and user)

### DIFF
--- a/Quickfeed/Managers/GRPCManager.swift
+++ b/Quickfeed/Managers/GRPCManager.swift
@@ -125,13 +125,13 @@ class GRPCManager {
         var request = GroupRequest()
         request.userID = userID
         request.courseID = courseID
-
+        
         if groupID != nil{
             request.groupID = groupID!
         }
-
+        
         let call = self.quickfeedClient.getGroupByUserAndCourse(request, callOptions: self.defaultOptions)
-
+        
         do {
             let response = try call.response.wait()
             return response
@@ -144,15 +144,15 @@ class GRPCManager {
     func getGroupsByCourse(courseID: UInt64) -> EventLoopFuture<Groups>{
         var request = CourseRequest()
         request.courseID = courseID
-
+        
         let call = self.quickfeedClient.getGroupsByCourse(request, callOptions: self.defaultOptions)
-
+        
         return call.response
     }
     
     func createGroup(group: Group) -> EventLoopFuture<Group>{
         let call = self.quickfeedClient.createGroup(group, callOptions: self.defaultOptions)
-
+        
         return call.response
     }
     
@@ -174,9 +174,9 @@ class GRPCManager {
         var request = EnrollmentStatusRequest()
         request.userID = userID
         request.statuses = userStatus
-
+        
         let call = self.quickfeedClient.getEnrollmentsByUser(request, callOptions: self.defaultOptions)
-
+        
         do {
             let response = try call.response.wait()
             return response.enrollments
@@ -197,7 +197,7 @@ class GRPCManager {
         if withActivity != nil {
             request.withActivity = withActivity!
         }
-
+        
         let call = self.quickfeedClient.getEnrollmentsByCourse(request, callOptions: self.defaultOptions)
         
         return call.response
@@ -301,7 +301,7 @@ class GRPCManager {
     func updateAssignments(courseID: UInt64) -> Bool{
         var request = CourseRequest()
         request.courseID = courseID
-
+        
         let call = self.quickfeedClient.updateAssignments(request, callOptions: self.defaultOptions)
         
         do {
@@ -341,7 +341,7 @@ class GRPCManager {
         var request = SubmissionsForCourseRequest()
         request.courseID = courseID
         request.type = type
-
+        
         let call = self.quickfeedClient.getSubmissionsByCourse(request, callOptions: self.defaultOptions)
         
         return call.response
@@ -354,7 +354,7 @@ class GRPCManager {
         request.score = score
         request.released = released
         request.status = status
-
+        
         let call = self.quickfeedClient.updateSubmission(request, callOptions: self.defaultOptions)
         
         do {
@@ -507,7 +507,7 @@ class GRPCManager {
     func getOrganization(orgName: String) -> EventLoopFuture<Organization>{
         var request = OrgRequest()
         request.orgName = orgName
-
+        
         let call = self.quickfeedClient.getOrganization(request, callOptions: self.defaultOptions)
         
         return call.response

--- a/Quickfeed/Managers/GitHubManager.swift
+++ b/Quickfeed/Managers/GitHubManager.swift
@@ -20,7 +20,7 @@ class GitHubManager: NSObject, ObservableObject, ASWebAuthenticationPresentation
     }
     
     func logInWithGitHub() {
-        self.viewModel.setUser(userID: 61)
+        self.viewModel.setUser(userID: 100)
         /*guard let authURL = URL(string: "https://QuickFeed.no/auth/github/github") else { return }
         let session = ASWebAuthenticationSession(url: authURL, callbackURLScheme: "quickfeed", completionHandler: { (callbackURL, error) in
             guard error == nil, let callbackURL = callbackURL else { return }

--- a/Quickfeed/Managers/GitHubManager.swift
+++ b/Quickfeed/Managers/GitHubManager.swift
@@ -20,7 +20,7 @@ class GitHubManager: NSObject, ObservableObject, ASWebAuthenticationPresentation
     }
     
     func logInWithGitHub() {
-        self.viewModel.setUser(userID: 61)
+        self.viewModel.setUser(userID: 221)
         /*guard let authURL = URL(string: "https://QuickFeed.no/auth/github/github") else { return }
         let session = ASWebAuthenticationSession(url: authURL, callbackURLScheme: "quickfeed", completionHandler: { (callbackURL, error) in
             guard error == nil, let callbackURL = callbackURL else { return }

--- a/Quickfeed/Managers/GitHubManager.swift
+++ b/Quickfeed/Managers/GitHubManager.swift
@@ -20,7 +20,7 @@ class GitHubManager: NSObject, ObservableObject, ASWebAuthenticationPresentation
     }
     
     func logInWithGitHub() {
-        self.viewModel.setUser(userID: 100)
+        self.viewModel.setUser(userID: 61)
         /*guard let authURL = URL(string: "https://QuickFeed.no/auth/github/github") else { return }
         let session = ASWebAuthenticationSession(url: authURL, callbackURLScheme: "quickfeed", completionHandler: { (callbackURL, error) in
             guard error == nil, let callbackURL = callbackURL else { return }

--- a/Quickfeed/Managers/GitHubManager.swift
+++ b/Quickfeed/Managers/GitHubManager.swift
@@ -20,7 +20,7 @@ class GitHubManager: NSObject, ObservableObject, ASWebAuthenticationPresentation
     }
     
     func logInWithGitHub() {
-        self.viewModel.setUser(userID: 221)
+        self.viewModel.setUser(userID: 61)
         /*guard let authURL = URL(string: "https://QuickFeed.no/auth/github/github") else { return }
         let session = ASWebAuthenticationSession(url: authURL, callbackURLScheme: "quickfeed", completionHandler: { (callbackURL, error) in
             guard error == nil, let callbackURL = callbackURL else { return }

--- a/Quickfeed/ViewModels/AdminViewModel.swift
+++ b/Quickfeed/ViewModels/AdminViewModel.swift
@@ -12,8 +12,8 @@ class AdminViewModel: UserViewModelProtocol {
     
     var user: User = ServerProvider.shared.getUser()!
     
-    @Published var users: [User]?
-    @Published var courses: [Course]?
+    @Published var users: [User] = []
+    @Published var courses: [Course] = []
     
     private init() {
         print("New AdminViewModel")
@@ -23,7 +23,11 @@ class AdminViewModel: UserViewModelProtocol {
     
     // MARK: Users
     func getUsers(){
-        self.users = provider.getUsers()
+        let users = provider.getUsers()
+        
+        if users != nil {
+            self.users = users!
+        }
     }
     
     func updateUser(user: User){
@@ -37,7 +41,11 @@ class AdminViewModel: UserViewModelProtocol {
     
     // MARK: Courses
     func getCourses(){
-        self.courses = provider.getCourses()
+        let courses = provider.getCourses()
+        
+        if courses != nil {
+            self.courses = courses!
+        }
     }
     
     func createCourse(name: String, code: String, year: String, tag: String, slipDays: UInt32){
@@ -49,7 +57,7 @@ class AdminViewModel: UserViewModelProtocol {
         course.tag = tag
         course.slipDays = slipDays
         
-        provider.createCourse(course: course)
+        _ = provider.createCourse(course: course)
         self.getCourses()
     }
     

--- a/Quickfeed/ViewModels/AdminViewModel.swift
+++ b/Quickfeed/ViewModels/AdminViewModel.swift
@@ -7,8 +7,11 @@ import Foundation
 
 class AdminViewModel: UserViewModelProtocol {
     static let shared: AdminViewModel = AdminViewModel()
+    
     var provider: ProviderProtocol = ServerProvider.shared
+    
     var user: User = ServerProvider.shared.getUser()!
+    
     @Published var users: [User]?
     @Published var courses: [Course]?
     
@@ -31,21 +34,8 @@ class AdminViewModel: UserViewModelProtocol {
     }
     
     // MARK: Courses
-    func getOrganization(orgName: String) -> Bool{
-        var errString: String = ""
-        let response = self.provider.getOrganization(orgName: orgName)
-        _ = response.always {(response: Result<Organization, Error>) in
-            switch response {
-            case .success( _):
-                DispatchQueue.main.async {
-                    errString = ""
-                }
-            case .failure(let err):
-                print("[Error] Connection error or invalid accesstoken: \(err)")
-                errString = "Error"
-            }
-        }
-        return errString == ""
+    func getCourses(){
+        self.courses = provider.getCourses()
     }
     
     func createCourse(name: String, code: String, year: String, tag: String, slipDays: UInt32){
@@ -70,8 +60,22 @@ class AdminViewModel: UserViewModelProtocol {
         self.getCourses()
     }
     
-    func getCourses(){
-        self.courses = provider.getCourses()
+    // MARK: Misc
+    func getOrganization(orgName: String) -> Bool{
+        var errString: String = ""
+        let response = self.provider.getOrganization(orgName: orgName)
+        _ = response.always {(response: Result<Organization, Error>) in
+            switch response {
+            case .success( _):
+                DispatchQueue.main.async {
+                    errString = ""
+                }
+            case .failure(let err):
+                print("[Error] Connection error or invalid accesstoken: \(err)")
+                errString = "Error"
+            }
+        }
+        return errString == ""
     }
     
     func reset() {

--- a/Quickfeed/ViewModels/AdminViewModel.swift
+++ b/Quickfeed/ViewModels/AdminViewModel.swift
@@ -18,7 +18,7 @@ class AdminViewModel: UserViewModelProtocol {
         getCourses()
     }
     
-    // Users
+    // MARK: Users
     func getUsers(){
         self.users = provider.getUsers()
     }
@@ -30,7 +30,7 @@ class AdminViewModel: UserViewModelProtocol {
         self.getUsers()
     }
     
-    // Courses
+    // MARK: Courses
     func getOrganization(orgName: String) -> Bool{
         var errString: String = ""
         let response = self.provider.getOrganization(orgName: orgName)

--- a/Quickfeed/ViewModels/AdminViewModel.swift
+++ b/Quickfeed/ViewModels/AdminViewModel.swift
@@ -28,7 +28,9 @@ class AdminViewModel: UserViewModelProtocol {
     
     func updateUser(user: User){
         var user = user
+        
         user.isAdmin = !user.isAdmin
+        
         provider.updateUser(user: user)
         self.getUsers()
     }
@@ -40,22 +42,26 @@ class AdminViewModel: UserViewModelProtocol {
     
     func createCourse(name: String, code: String, year: String, tag: String, slipDays: UInt32){
         var course = Course()
+        
         course.name = name
         course.code = code
         course.year = UInt32(year)!
         course.tag = tag
         course.slipDays = slipDays
-        provider.updateCourse(course: course)
+        
+        provider.createCourse(course: course)
         self.getCourses()
     }
     
     func updateCourse(course: Course, name: String, code: String, year: String, tag: String, slipDays: UInt32){
         var course = course
+        
         course.name = name
         course.code = code
         course.year = UInt32(year)!
         course.tag = tag
         course.slipDays = slipDays
+        
         provider.updateCourse(course: course)
         self.getCourses()
     }

--- a/Quickfeed/ViewModels/StudentViewModel.swift
+++ b/Quickfeed/ViewModels/StudentViewModel.swift
@@ -20,11 +20,9 @@ class StudentViewModel: UserViewModelProtocol{
         print("New StudentViewModel")
     }
     
-    func setCourse(course: Course){
-        self.course = course
-        self.group = provider.getGroupByUserAndCourse(courseID: course.id, groupID: nil, userID: user.id)
-    }
+    // MARK: Users
     
+    // MARK: Groups
     func createGroup(name: String, enrollments: [Enrollment]) {
         var users: [User] = []
         for element in enrollments{
@@ -53,6 +51,7 @@ class StudentViewModel: UserViewModelProtocol{
         }
     }
     
+    // MARK: Enrollments
     func getEnrollmentForCurrentCourse() -> Enrollment?{
         let enrollments = provider.getEnrollmentsByUser(userID: self.user.id, userStatus: [Enrollment.UserStatus.teacher, Enrollment.UserStatus.student, Enrollment.UserStatus.pending])!
         for element in enrollments{
@@ -78,6 +77,23 @@ class StudentViewModel: UserViewModelProtocol{
         }
     }
     
+    // MARK: Courses
+    func setCourse(course: Course){
+        self.course = course
+        self.group = provider.getGroupByUserAndCourse(courseID: course.id, groupID: nil, userID: user.id)
+    }
+    
+    func getSlipdays() -> UInt32? {
+        let enrollments = provider.getEnrollmentsByUser(userID: self.user.id, userStatus: [Enrollment.UserStatus.teacher, Enrollment.UserStatus.student, Enrollment.UserStatus.pending])!
+        for element in enrollments{
+            if element.courseID == course!.id{
+                return element.slipDaysRemaining
+            }
+        }
+        return nil
+    }
+    
+    // MARK: Assignments
     func getAssignments(){
         self.assignments = provider.getAssignments(courseID: course!.id)!
     }
@@ -93,6 +109,7 @@ class StudentViewModel: UserViewModelProtocol{
         return false
     }
     
+    // MARK: Submissions
     func getSubmission(assignment: Assignment) -> Submission? {
         if self.submissions != nil {
             for element in self.submissions! {
@@ -116,16 +133,7 @@ class StudentViewModel: UserViewModelProtocol{
         self.submissions = submissions
     }
     
-    func getSlipdays() -> UInt32? {
-        let enrollments = provider.getEnrollmentsByUser(userID: self.user.id, userStatus: [Enrollment.UserStatus.teacher, Enrollment.UserStatus.student, Enrollment.UserStatus.pending])!
-        for element in enrollments{
-            if element.courseID == course!.id{
-                return element.slipDaysRemaining
-            }
-        }
-        return nil
-    }
-    
+    // MARK: Manual Grading
     func getReviews(reviews: [Review]) -> [Review]{
         var reviews = reviews
         for review in reviews{
@@ -149,6 +157,7 @@ class StudentViewModel: UserViewModelProtocol{
         return nil
     }
     
+    // MARK: Misc    
     func reload() {
         self.getAssignments()
         self.getSubmissions()

--- a/Quickfeed/ViewModels/StudentViewModel.swift
+++ b/Quickfeed/ViewModels/StudentViewModel.swift
@@ -15,7 +15,7 @@ class StudentViewModel: UserViewModelProtocol{
     
     @Published var course: Course?
     @Published var group: Group?
-    @Published var assignments: [Assignment]?
+    @Published var assignments: [Assignment] = []
     @Published var submissions: [Submission]?
     @Published var enrollments: [Enrollment] = []
     
@@ -92,11 +92,9 @@ class StudentViewModel: UserViewModelProtocol{
     }
     
     func hasGroupAssignments() -> Bool{
-        if self.assignments != nil{
-            for assignment in self.assignments!{
-                if assignment.isGroupLab{
-                    return true
-                }
+        for assignment in self.assignments{
+            if assignment.isGroupLab{
+                return true
             }
         }
         return false
@@ -155,7 +153,6 @@ class StudentViewModel: UserViewModelProtocol{
         self.getAssignments()
         self.getSubmissions()
     }
-    
     
     func reset() {
         

--- a/Quickfeed/ViewModels/StudentViewModel.swift
+++ b/Quickfeed/ViewModels/StudentViewModel.swift
@@ -16,7 +16,7 @@ class StudentViewModel: UserViewModelProtocol{
     @Published var course: Course?
     @Published var group: Group?
     @Published var assignments: [Assignment] = []
-    @Published var submissions: [Submission]?
+    @Published var submissions: [Submission] = []
     @Published var enrollments: [Enrollment] = []
     
     private init() {
@@ -102,17 +102,16 @@ class StudentViewModel: UserViewModelProtocol{
     
     // MARK: Submissions
     func getSubmission(assignment: Assignment) -> Submission? {
-        if self.submissions != nil {
-            for element in self.submissions! {
-                if element.assignmentID == assignment.id {
-                    if assignment.isGroupLab && element.groupID != 0 {
-                        return element
-                    } else if !assignment.isGroupLab && element.groupID == 0{
-                        return element
-                    }
+        for element in self.submissions {
+            if element.assignmentID == assignment.id {
+                if assignment.isGroupLab && element.groupID != 0 {
+                    return element
+                } else if !assignment.isGroupLab && element.groupID == 0{
+                    return element
                 }
             }
         }
+        
         return nil
     }
     

--- a/Quickfeed/ViewModels/StudentViewModel.swift
+++ b/Quickfeed/ViewModels/StudentViewModel.swift
@@ -35,6 +35,7 @@ class StudentViewModel: UserViewModelProtocol{
         group.status = Group.GroupStatus.pending
         group.courseID = course!.id
         group.users = users
+        self.group = provider.getGroupByUserAndCourse(courseID: self.course!.id, groupID: nil, userID: user.id)
         
         let response = self.provider.createGroup(group: group)
         _ = response.always {(response: Result<Group, Error>) in
@@ -50,7 +51,7 @@ class StudentViewModel: UserViewModelProtocol{
     }
     
     // MARK: Enrollments
-    func getEnrollmentForCurrentCourse() -> Enrollment?{
+    func getEnrollment() -> Enrollment?{
         let enrollments = provider.getEnrollmentsByUser(userID: self.user.id, userStatus: [Enrollment.UserStatus.teacher, Enrollment.UserStatus.student, Enrollment.UserStatus.pending])!
         for element in enrollments{
             if element.course.id == course!.id{
@@ -82,13 +83,7 @@ class StudentViewModel: UserViewModelProtocol{
     }
     
     func getSlipdays() -> UInt32? {
-        let enrollments = provider.getEnrollmentsByUser(userID: self.user.id, userStatus: [Enrollment.UserStatus.teacher, Enrollment.UserStatus.student, Enrollment.UserStatus.pending])!
-        for element in enrollments{
-            if element.courseID == course!.id{
-                return element.slipDaysRemaining
-            }
-        }
-        return nil
+        return getEnrollment()!.slipDaysRemaining
     }
     
     // MARK: Assignments

--- a/Quickfeed/ViewModels/StudentViewModel.swift
+++ b/Quickfeed/ViewModels/StudentViewModel.swift
@@ -88,7 +88,14 @@ class StudentViewModel: UserViewModelProtocol{
     
     // MARK: Assignments
     func getAssignments(){
-        self.assignments = provider.getAssignments(courseID: course!.id)!
+        let assignments = provider.getAssignments(courseID: course!.id)
+        
+        if assignments == nil {
+            self.assignments = []
+        } else {
+            self.assignments = assignments!
+        }
+        //self.assignments = provider.getAssignments(courseID: course!.id)!
     }
     
     func hasGroupAssignments() -> Bool{

--- a/Quickfeed/ViewModels/StudentViewModel.swift
+++ b/Quickfeed/ViewModels/StudentViewModel.swift
@@ -21,7 +21,9 @@ class StudentViewModel: UserViewModelProtocol{
     init(course: Course) {
         print("New StudentViewModel")
         self.course = course
+        
         self.group = provider.getGroupByUserAndCourse(courseID: course.id, groupID: nil, userID: user.id)
+        
         getAssignments()
         getSubmissions()
     }

--- a/Quickfeed/ViewModels/StudentViewModel.swift
+++ b/Quickfeed/ViewModels/StudentViewModel.swift
@@ -80,11 +80,6 @@ class StudentViewModel: UserViewModelProtocol{
     }
     
     // MARK: Courses
-    func setCourse(course: Course){
-        self.course = course
-        self.group = provider.getGroupByUserAndCourse(courseID: course.id, groupID: nil, userID: user.id)
-    }
-    
     func getSlipdays() -> UInt32? {
         return getEnrollment()!.slipDaysRemaining
     }

--- a/Quickfeed/ViewModels/StudentViewModel.swift
+++ b/Quickfeed/ViewModels/StudentViewModel.swift
@@ -20,8 +20,6 @@ class StudentViewModel: UserViewModelProtocol{
         print("New StudentViewModel")
     }
     
-    // MARK: Users
-    
     // MARK: Groups
     func createGroup(name: String, enrollments: [Enrollment]) {
         var users: [User] = []
@@ -157,7 +155,7 @@ class StudentViewModel: UserViewModelProtocol{
         return nil
     }
     
-    // MARK: Misc    
+    // MARK: Misc
     func reload() {
         self.getAssignments()
         self.getSubmissions()

--- a/Quickfeed/ViewModels/StudentViewModel.swift
+++ b/Quickfeed/ViewModels/StudentViewModel.swift
@@ -8,8 +8,11 @@ import Foundation
 
 class StudentViewModel: UserViewModelProtocol{
     static let shared: StudentViewModel = StudentViewModel()
+    
     var provider: ProviderProtocol = ServerProvider.shared
+    
     @Published var user: User = ServerProvider.shared.getUser()!
+    
     @Published var course: Course?
     @Published var group: Group?
     @Published var assignments: [Assignment]?
@@ -33,18 +36,15 @@ class StudentViewModel: UserViewModelProtocol{
         group.courseID = course!.id
         group.users = users
         
-        var errString: String? = nil
         let response = self.provider.createGroup(group: group)
         _ = response.always {(response: Result<Group, Error>) in
             switch response {
             case .success( _):
                 DispatchQueue.main.async {
-                    errString = nil
-                    print("yey")
+                    print("Group created")
                 }
             case .failure(let err):
                 print("[Error] Connection error or groups not found: \(err)")
-                errString = err.localizedDescription
             }
         }
     }

--- a/Quickfeed/ViewModels/StudentViewModel.swift
+++ b/Quickfeed/ViewModels/StudentViewModel.swift
@@ -90,12 +90,9 @@ class StudentViewModel: UserViewModelProtocol{
     func getAssignments(){
         let assignments = provider.getAssignments(courseID: course!.id)
         
-        if assignments == nil {
-            self.assignments = []
-        } else {
+        if assignments != nil {
             self.assignments = assignments!
         }
-        //self.assignments = provider.getAssignments(courseID: course!.id)!
     }
     
     func hasGroupAssignments() -> Bool{
@@ -123,10 +120,20 @@ class StudentViewModel: UserViewModelProtocol{
     }
     
     func getSubmissions(){
-        var submissions = provider.getSubmissions(userID: user.id, groupID: nil, courseID: course!.id)!
-        if self.group != nil{
-            submissions.append(contentsOf: provider.getSubmissions(userID: nil, groupID: group!.id, courseID: course!.id)!)
+        var submissions: [Submission] = []
+        
+        let individualSubmissions = provider.getSubmissions(userID: user.id, groupID: nil, courseID: course!.id)
+        if individualSubmissions != nil {
+            submissions.append(contentsOf: individualSubmissions!)
         }
+        
+        if group != nil {
+            let groupSubmissions = provider.getSubmissions(userID: nil, groupID: group!.id, courseID: course!.id)
+            if groupSubmissions != nil {
+                submissions.append(contentsOf: groupSubmissions!)
+            }
+        }
+        
         self.submissions = submissions
     }
     

--- a/Quickfeed/ViewModels/UserViewModel.swift
+++ b/Quickfeed/ViewModels/UserViewModel.swift
@@ -9,7 +9,7 @@ class UserViewModel: UserViewModelProtocol {
     var provider: ProviderProtocol = ServerProvider.shared
     
     @Published var user: User?
-    @Published var courses: [Course]?
+    @Published var courses: [Course] = []
     @Published var enrollments: [Enrollment] = []
     
     init() {
@@ -70,11 +70,9 @@ class UserViewModel: UserViewModelProtocol {
     
     // MARK: Courses
     func getCourse(courseID: UInt64) -> Course? {
-        if self.courses != nil {
-            for course in self.courses! {
-                if course.id == courseID {
-                    return course
-                }
+        for course in self.courses {
+            if course.id == courseID {
+                return course
             }
         }
         return nil
@@ -89,7 +87,7 @@ class UserViewModel: UserViewModelProtocol {
     }
     
     func getCoursesByUser() {
-        self.courses = self.provider.getCoursesByUser(userID: self.user!.id, userStatus: [Enrollment.UserStatus.student, Enrollment.UserStatus.teacher])
+        self.courses = self.provider.getCoursesByUser(userID: self.user!.id, userStatus: [Enrollment.UserStatus.student, Enrollment.UserStatus.teacher])!
     }
     
     func getCoursesForNewEnrollments() -> [Course]?{
@@ -112,13 +110,11 @@ class UserViewModel: UserViewModelProtocol {
     }
     
     func isTeacherForCourse(courseId: UInt64) -> Bool? {
-        if self.courses != nil {
-            for course in self.courses! {
+            for course in self.courses {
                 if course.id == courseId {
                     return course.enrolled == Enrollment.UserStatus.teacher ? true : false
                 }
             }
-        }
         
         return nil
     }

--- a/Quickfeed/ViewModels/UserViewModel.swift
+++ b/Quickfeed/ViewModels/UserViewModel.swift
@@ -17,7 +17,6 @@ class UserViewModel: UserViewModelProtocol {
     }
     
     // MARK: Users
-    
     func setUser(userID: UInt64){
         self.provider.setUser(userID: userID)
         self.getUser()
@@ -38,7 +37,6 @@ class UserViewModel: UserViewModelProtocol {
     }
     
     // MARK: Enrollments
-    
     func createEnrollment(courseID: UInt64) {
         var enrollment = Enrollment()
         enrollment.courseID = courseID
@@ -92,7 +90,6 @@ class UserViewModel: UserViewModelProtocol {
     }
     
     // MARK: Courses
-    
     func getCourse(courseID: UInt64) -> Course? {
         if self.courses != nil {
             for course in self.courses! {

--- a/Quickfeed/ViewModels/UserViewModel.swift
+++ b/Quickfeed/ViewModels/UserViewModel.swift
@@ -7,6 +7,7 @@ import Foundation
 
 class UserViewModel: UserViewModelProtocol {
     var provider: ProviderProtocol = ServerProvider.shared
+    
     @Published var user: User?
     @Published var courses: [Course]?
     @Published var enrollments: [Enrollment] = []
@@ -15,7 +16,7 @@ class UserViewModel: UserViewModelProtocol {
         print("New UserViewModel")
     }
     
-    // User
+    // MARK: Users
     
     func setUser(userID: UInt64){
         self.provider.setUser(userID: userID)
@@ -36,50 +37,7 @@ class UserViewModel: UserViewModelProtocol {
         self.getUser()
     }
     
-    // Course
-    
-    func getCourse(courseID: UInt64) -> Course? {
-        if self.courses != nil {
-            for course in self.courses! {
-                if course.id == courseID {
-                    return course
-                }
-            }
-        }
-        return nil
-    }
-    
-    func getCourseById(courseId: UInt64) -> Course{
-        return self.provider.getCourse(courseID: courseId)!
-    }
-    
-    func getAllCourses() -> [Course]? {
-        return provider.getCourses()
-    }
-    
-    func getAllCoursesForCurrentUser() {
-        self.courses = self.provider.getCoursesByUser(userID: self.user!.id, userStatus: [Enrollment.UserStatus.student, Enrollment.UserStatus.teacher])
-    }
-    
-    func isTeacherForCourse(courseId: UInt64) -> Bool? {
-        if self.courses != nil {
-            for course in self.courses! {
-                if course.id == courseId {
-                    return course.enrolled == Enrollment.UserStatus.teacher ? true : false
-                }
-            }
-        }
-        
-        return nil
-    }
-    
-    func sortCourseByCode(courses: [Course]) -> [Course] {
-        var courses = courses
-        courses.sort { $0.code < $1.code }
-        return courses
-    }
-    
-    // Enrollment
+    // MARK: Enrollments
     
     func createEnrollment(courseID: UInt64) {
         var enrollment = Enrollment()
@@ -133,6 +91,48 @@ class UserViewModel: UserViewModelProtocol {
         self.enrollments = enrollments
     }
     
+    // MARK: Courses
+    
+    func getCourse(courseID: UInt64) -> Course? {
+        if self.courses != nil {
+            for course in self.courses! {
+                if course.id == courseID {
+                    return course
+                }
+            }
+        }
+        return nil
+    }
+    
+    func getCourseById(courseId: UInt64) -> Course{
+        return self.provider.getCourse(courseID: courseId)!
+    }
+    
+    func getAllCourses() -> [Course]? {
+        return provider.getCourses()
+    }
+    
+    func getAllCoursesForCurrentUser() {
+        self.courses = self.provider.getCoursesByUser(userID: self.user!.id, userStatus: [Enrollment.UserStatus.student, Enrollment.UserStatus.teacher])
+    }
+    
+    func isTeacherForCourse(courseId: UInt64) -> Bool? {
+        if self.courses != nil {
+            for course in self.courses! {
+                if course.id == courseId {
+                    return course.enrolled == Enrollment.UserStatus.teacher ? true : false
+                }
+            }
+        }
+        
+        return nil
+    }
+    
+    func sortCourseByCode(courses: [Course]) -> [Course] {
+        var courses = courses
+        courses.sort { $0.code < $1.code }
+        return courses
+    }
     
     func reset() {
         

--- a/Quickfeed/ViewModels/UserViewModel.swift
+++ b/Quickfeed/ViewModels/UserViewModel.swift
@@ -40,6 +40,7 @@ class UserViewModel: UserViewModelProtocol {
     // MARK: Enrollments
     func createEnrollment(courseID: UInt64) {
         var enrollment = Enrollment()
+        
         enrollment.courseID = courseID
         enrollment.userID = self.user!.id
         

--- a/Quickfeed/ViewModels/UserViewModel.swift
+++ b/Quickfeed/ViewModels/UserViewModel.swift
@@ -24,7 +24,7 @@ class UserViewModel: UserViewModelProtocol {
     
     func getUser() {
         self.user = provider.getUser()!
-        self.getAllCoursesForCurrentUser()
+        self.getCoursesByUser()
         self.getEnrollments()
     }
     
@@ -32,6 +32,7 @@ class UserViewModel: UserViewModelProtocol {
         self.user!.name = name
         self.user!.studentID = studentID
         self.user!.email = email
+        
         self.provider.updateUser(user: self.user!)
         self.getUser()
     }
@@ -47,11 +48,9 @@ class UserViewModel: UserViewModelProtocol {
     }
     
     func getEnrollmentByCourse(courseID: UInt64) -> Enrollment?{
-        if self.enrollments.count > 0 {
-            for enrollment in self.enrollments {
-                if enrollment.courseID == courseID {
-                    return enrollment
-                }
+        for enrollment in self.enrollments {
+            if enrollment.courseID == courseID {
+                return enrollment
             }
         }
         return nil
@@ -59,28 +58,8 @@ class UserViewModel: UserViewModelProtocol {
     
     func getEnrollments() {
         self.enrollments = self.provider.getEnrollmentsByUser(userID: self.user!.id, userStatus: [Enrollment.UserStatus.teacher, Enrollment.UserStatus.student, Enrollment.UserStatus.pending])!
-        if self.enrollments.count != 0 {
-            self.sortEnrollmentsByCode()
-        }
-    }
-    
-    func getCoursesForNewEnrollments() -> [Course]?{
-        var courses = self.getAllCourses()
-        if courses?.count != 0 {
-            for course in courses! {
-                if self.enrollments.count != 0{
-                    for enrollment in self.enrollments {
-                        if course.id == enrollment.courseID {
-                            if let index = courses!.firstIndex(of: course) {
-                                courses!.remove(at: index)
-                            }
-                        }
-                    }
-                }
-            }
-            return courses
-        }
-        return nil
+        
+        self.sortEnrollmentsByCode()
     }
     
     private func sortEnrollmentsByCode() {
@@ -109,8 +88,27 @@ class UserViewModel: UserViewModelProtocol {
         return provider.getCourses()
     }
     
-    func getAllCoursesForCurrentUser() {
+    func getCoursesByUser() {
         self.courses = self.provider.getCoursesByUser(userID: self.user!.id, userStatus: [Enrollment.UserStatus.student, Enrollment.UserStatus.teacher])
+    }
+    
+    func getCoursesForNewEnrollments() -> [Course]?{
+        var courses = self.getAllCourses()
+        if courses?.count != 0 {
+            for course in courses! {
+                if self.enrollments.count != 0{
+                    for enrollment in self.enrollments {
+                        if course.id == enrollment.courseID {
+                            if let index = courses!.firstIndex(of: course) {
+                                courses!.remove(at: index)
+                            }
+                        }
+                    }
+                }
+            }
+            return courses
+        }
+        return nil
     }
     
     func isTeacherForCourse(courseId: UInt64) -> Bool? {

--- a/Quickfeed/ViewModels/UserViewModel.swift
+++ b/Quickfeed/ViewModels/UserViewModel.swift
@@ -82,7 +82,7 @@ class UserViewModel: UserViewModelProtocol {
         return self.provider.getCourse(courseID: courseId)!
     }
     
-    func getAllCourses() -> [Course]? {
+    func getCourses() -> [Course]? {
         return provider.getCourses()
     }
     
@@ -91,7 +91,7 @@ class UserViewModel: UserViewModelProtocol {
     }
     
     func getCoursesForNewEnrollments() -> [Course]?{
-        var courses = self.getAllCourses()
+        var courses = self.getCourses()
         if courses?.count != 0 {
             for course in courses! {
                 if self.enrollments.count != 0{
@@ -110,11 +110,11 @@ class UserViewModel: UserViewModelProtocol {
     }
     
     func isTeacherForCourse(courseId: UInt64) -> Bool? {
-            for course in self.courses {
-                if course.id == courseId {
-                    return course.enrolled == Enrollment.UserStatus.teacher ? true : false
-                }
+        for course in self.courses {
+            if course.id == courseId {
+                return course.enrolled == Enrollment.UserStatus.teacher ? true : false
             }
+        }
         
         return nil
     }

--- a/Quickfeed/Views/Admin/AdminUsers.swift
+++ b/Quickfeed/Views/Admin/AdminUsers.swift
@@ -68,7 +68,7 @@ struct AdminUsers: View {
     }
     
     func filteredUsers() -> [User] {
-        var users = viewModel.users!
+        var users = viewModel.users
         users.sort {
             if $0.isAdmin != $1.isAdmin{
                 return $0.isAdmin && !$1.isAdmin

--- a/Quickfeed/Views/Admin/Courses/AllCourses.swift
+++ b/Quickfeed/Views/Admin/Courses/AllCourses.swift
@@ -80,7 +80,7 @@ struct AllCourses: View {
     }
     
     func filteredCourse() -> [Course] {
-        var courses = viewModel.courses!
+        var courses = viewModel.courses
         courses.sort { $0.code < $1.code }
         return courses.filter({ matchesQuery(searchQuery: searchQuery, course: $0) })
     }

--- a/Quickfeed/Views/ContentView.swift
+++ b/Quickfeed/Views/ContentView.swift
@@ -18,10 +18,10 @@ struct ContentView: View {
         } else {
             if viewModel.user!.name == "" || viewModel.user!.email == "" || viewModel.user!.studentID == "" {
                 NewUser(viewModel: viewModel)
-            } else if viewModel.courses == [] || viewModel.courses == nil{
+            } else if viewModel.courses == [] {
                 NavigatorView(viewModel: viewModel, selectedCourse: 0, login: $login)
             }else {
-                NavigatorView(viewModel: viewModel, selectedCourse: viewModel.courses![0].id, login: $login)
+                NavigatorView(viewModel: viewModel, selectedCourse: viewModel.courses[0].id, login: $login)
             }
         }
     }

--- a/Quickfeed/Views/Helpers/LabSection.swift
+++ b/Quickfeed/Views/Helpers/LabSection.swift
@@ -8,15 +8,15 @@ import SwiftUI
 struct LabSection: View {
     @ObservedObject var viewModel: StudentViewModel
     @State private var activeDest: Int? = 0
-    var assignments: [Assignment]? { return viewModel.assignments }
+    var assignments: [Assignment] { return viewModel.assignments }
     
     var body: some View {
-        if assignments == nil {
+        if assignments.isEmpty {
             Text("No Assignments yet")
         } else {
             Section(header: Text("Labs")){
-                ForEach(assignments!, id: \.id){ assignment in
-                    NavigationLink(destination: StudentLab(viewModel: viewModel, assignment: assignment, submission: viewModel.getSubmission(assignment: assignment)), tag: (assignments?.firstIndex(of: assignment))!, selection: $activeDest){
+                ForEach(assignments, id: \.id){ assignment in
+                    NavigationLink(destination: StudentLab(viewModel: viewModel, assignment: assignment, submission: viewModel.getSubmission(assignment: assignment)), tag: (assignments.firstIndex(of: assignment)!), selection: $activeDest){
                         if viewModel.getSubmission(assignment: assignment) != nil {
                             getImageForSubmissionStatus(submission: viewModel.getSubmission(assignment: assignment)!.status)
                                 .frame(width: 5)

--- a/Quickfeed/Views/NavigatorView.swift
+++ b/Quickfeed/Views/NavigatorView.swift
@@ -23,7 +23,7 @@ struct NavigatorView: View {
                     if viewModel.isTeacherForCourse(courseId: selectedCourse)! {
                         TeacherNavigationView(viewModel: TeacherViewModel(provider: ServerProvider.shared, course: viewModel.getCourse(courseID: selectedCourse)!))
                     } else {
-                        StudentNavigatorView(viewModelTest: StudentViewModel.shared, course: viewModel.getCourse(courseID: selectedCourse)!)
+                        StudentNavigatorView(viewModel: StudentViewModel(course: viewModel.getCourse(courseID: selectedCourse)!))
                     }
                 }
                 

--- a/Quickfeed/Views/NavigatorView.swift
+++ b/Quickfeed/Views/NavigatorView.swift
@@ -21,7 +21,7 @@ struct NavigatorView: View {
                         .padding([.horizontal, .top])
                     
                     if viewModel.isTeacherForCourse(courseId: selectedCourse)! {
-                        TeacherNavigationView(viewModel: TeacherViewModel(provider: ServerProvider.shared, course: viewModel.getCourse(courseID: selectedCourse)!))
+                        TeacherNavigationView(viewModel: TeacherViewModel(course: viewModel.getCourse(courseID: selectedCourse)!))
                     } else {
                         StudentNavigatorView(viewModel: StudentViewModel(course: viewModel.getCourse(courseID: selectedCourse)!))
                     }

--- a/Quickfeed/Views/NavigatorView.swift
+++ b/Quickfeed/Views/NavigatorView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 
 struct NavigatorView: View {
     @ObservedObject var viewModel: UserViewModel
-    var courses: [Course] { return viewModel.courses! }
+    var courses: [Course] { return viewModel.courses }
     @State var selectedCourse: UInt64
     @Binding var login: Bool
     @State private var activeDest: Int? = 1
@@ -16,7 +16,7 @@ struct NavigatorView: View {
         NavigationView{
             VStack(alignment: .leading){
                 
-                if viewModel.courses != nil && viewModel.courses != []{
+                if viewModel.courses != []{
                     CoursePicker(courses: courses, selectedCourse: $selectedCourse)
                         .padding([.horizontal, .top])
                     

--- a/Quickfeed/Views/Student/NewGroup.swift
+++ b/Quickfeed/Views/Student/NewGroup.swift
@@ -57,7 +57,7 @@ struct NewGroup: View {
             self.selectedMembers.append(enrollment!)
         })
         .navigationTitle("New Group")
-        .navigationSubtitle(viewModel.course!.name)
+        .navigationSubtitle(viewModel.course.name)
         .toolbar{
             ToolbarItem{
                 SearchFieldToolbarItem(isSearching: $isSearching, searchQuery: $searchQuery)

--- a/Quickfeed/Views/Student/NewGroup.swift
+++ b/Quickfeed/Views/Student/NewGroup.swift
@@ -24,7 +24,7 @@ struct NewGroup: View {
                 Spacer()
                 TextField("Enter group name", text: $groupName)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
-                Button(action: {}, label: {
+                Button(action: { viewModel.createGroup(name: groupName, enrollments: selectedMembers) }, label: {
                     Text("Create group")
                 })
                 .disabled(selectedMembers.count > 0 && groupName != "" ? false : true)
@@ -53,7 +53,7 @@ struct NewGroup: View {
         .padding()
         .onAppear(perform:{
             viewModel.getEnrollmentsByCourse()
-            let enrollment = viewModel.getEnrollmentForCurrentCourse()
+            let enrollment = viewModel.getEnrollment()
             self.selectedMembers.append(enrollment!)
         })
         .navigationTitle("New Group")

--- a/Quickfeed/Views/Student/StudentNavigatorView.swift
+++ b/Quickfeed/Views/Student/StudentNavigatorView.swift
@@ -6,17 +6,11 @@
 import SwiftUI
 
 struct StudentNavigatorView: View {
-    @ObservedObject var viewModel: StudentViewModel = StudentViewModel.shared
-    
-    init(viewModelTest: StudentViewModel, course: Course) {
-        viewModel.setCourse(course: course)
-        viewModel.getAssignments()
-        viewModel.getSubmissions()
-    }
+    @ObservedObject var viewModel: StudentViewModel
     
     var body: some View {
         HStack{
-            if viewModel.course!.slipDays != 0 {
+            if viewModel.course.slipDays != 0 {
                 Text("Remaining SlipDays: \(viewModel.getSlipdays()!)")
                     .padding(.leading)
             } else {
@@ -45,7 +39,7 @@ struct StudentNavigatorView: View {
                     }
                 }
             }
-            GithubLinkSection(orgPath: viewModel.course!.organizationPath, userLogin: viewModel.user.login, group: viewModel.group, isTeacher: false)
+            GithubLinkSection(orgPath: viewModel.course.organizationPath, userLogin: viewModel.user.login, group: viewModel.group, isTeacher: false)
                 .padding(.leading)
         }
     }

--- a/Quickfeed/Views/Teacher/Assignments/AssignmentsView.swift
+++ b/Quickfeed/Views/Teacher/Assignments/AssignmentsView.swift
@@ -50,7 +50,7 @@ struct AssignmentsView: View {
             })
         })
         .navigationTitle("Assignments")
-        .navigationSubtitle(viewModel.currentCourse.name)
+        .navigationSubtitle(viewModel.course.name)
         .toolbar{
             ToolbarItem{
                 Button(action: {

--- a/Quickfeed/Views/Teacher/Groups/AddGroupForm.swift
+++ b/Quickfeed/Views/Teacher/Groups/AddGroupForm.swift
@@ -38,7 +38,7 @@ struct AddGroupForm: View {
     func createGroup(){
         viewModel.loadEnrollments()
         var group = Group()
-        group.courseID = viewModel.currentCourse.id
+        group.courseID = viewModel.course.id
         group.users = []
         for enr in selectedMembers{
             var user = User()
@@ -100,7 +100,7 @@ struct AddGroupForm: View {
             viewModel.loadEnrollments()
         })
         .navigationTitle("Add Group")
-        .navigationSubtitle(viewModel.currentCourse.name)
+        .navigationSubtitle(viewModel.course.name)
         .toolbar{
             ToolbarItem{
                 SearchFieldToolbarItem(isSearching: $isSearching, searchQuery: $searchQuery)

--- a/Quickfeed/Views/Teacher/Groups/GroupList.swift
+++ b/Quickfeed/Views/Teacher/Groups/GroupList.swift
@@ -75,7 +75,7 @@ struct GroupList: View {
             viewModel.loadGroups()
         })
         .navigationTitle("Groups")
-        .navigationSubtitle(viewModel.currentCourse.name)
+        .navigationSubtitle(viewModel.course.name)
         .toolbar{
             ToolbarItem(id: "edit"){
                 Toggle(isOn: $isEditing, label: {

--- a/Quickfeed/Views/Teacher/Members/MemberList.swift
+++ b/Quickfeed/Views/Teacher/Members/MemberList.swift
@@ -18,7 +18,7 @@ struct MemberList: View {
     }
     var body: some View {
         List{
-            Section(header: MemberListHeader(courseTotalSlipDays: self.viewModel.currentCourse.slipDays)){
+            Section(header: MemberListHeader(courseTotalSlipDays: self.viewModel.course.slipDays)){
                 ForEach(self.filteredEnrollments(), id: \.self){ enrollment in
                     MemberListItem(viewModel: viewModel, enrollment: enrollment, isEditing: $isEditing)
                     Divider()
@@ -30,7 +30,7 @@ struct MemberList: View {
             viewModel.loadEnrollments()
         })
         .navigationTitle("Members")
-        .navigationSubtitle(viewModel.currentCourse.name)
+        .navigationSubtitle(viewModel.course.name)
         .toolbar{
             ToolbarItem{
                 Toggle(isOn: $isEditing, label: {

--- a/Quickfeed/Views/Teacher/Members/MemberListItem.swift
+++ b/Quickfeed/Views/Teacher/Members/MemberListItem.swift
@@ -31,7 +31,7 @@ struct MemberListItem: View {
     var body: some View {
         HStack {
             SwiftUI.Group{
-                Link(destination: URL(string: "https://www.github.com/" + viewModel.currentCourse.organizationPath + "/" + enrollment.user.login + "-labs")!, label:{
+                Link(destination: URL(string: "https://www.github.com/" + viewModel.course.organizationPath + "/" + enrollment.user.login + "-labs")!, label:{
                     Text(enrollment.user.name)
                         .frame(width: 180, alignment: .leading)
                 })
@@ -64,7 +64,7 @@ struct MemberListItem: View {
             }
             
             SwiftUI.Group{
-                if viewModel.currentCourse.slipDays > 0 {
+                if viewModel.course.slipDays > 0 {
                     Text("\(enrollment.slipDaysRemaining)")
                         .frame(width: 60, alignment: .center)
                     Spacer()

--- a/Quickfeed/Views/Teacher/Release/ReleaseList.swift
+++ b/Quickfeed/Views/Teacher/Release/ReleaseList.swift
@@ -74,7 +74,7 @@ struct ReleaseList: View {
             viewModel.loadEnrollmentLinks()
         })
         .navigationTitle("Release Submissions")
-        .navigationSubtitle(viewModel.currentCourse.name)
+        .navigationSubtitle(viewModel.course.name)
         .toolbar{
             ToolbarItem{
                 LabPicker(labs: viewModel.manuallyGradedAssignments, selectedLab: $selectedLab)

--- a/Quickfeed/Views/Teacher/Results/ResultStats.swift
+++ b/Quickfeed/Views/Teacher/Results/ResultStats.swift
@@ -63,7 +63,7 @@ struct ResultStats: View {
             
         }
         .navigationTitle("Stats")
-        .navigationSubtitle(viewModel.currentCourse.name)
+        .navigationSubtitle(viewModel.course.name)
     }
 }
 

--- a/Quickfeed/Views/Teacher/Results/ResultView.swift
+++ b/Quickfeed/Views/Teacher/Results/ResultView.swift
@@ -29,7 +29,7 @@ struct ResultView: View {
         })
         .navigationTitle("Results")
         
-        .navigationSubtitle(viewModel.currentCourse.name)
+        .navigationSubtitle(viewModel.course.name)
        
     }
 }

--- a/Quickfeed/Views/Teacher/Review/ReviewList.swift
+++ b/Quickfeed/Views/Teacher/Review/ReviewList.swift
@@ -78,7 +78,7 @@ struct ReviewList: View {
             viewModel.loadEnrollmentLinks()
         })
         .navigationTitle("Review Submissions")
-        .navigationSubtitle(viewModel.currentCourse.name)
+        .navigationSubtitle(viewModel.course.name)
         .toolbar{
             ToolbarItem{
                 LabPicker(labs: viewModel.manuallyGradedAssignments, selectedLab: $selectedLab)

--- a/Quickfeed/Views/Teacher/Review/SubmissionReview.swift
+++ b/Quickfeed/Views/Teacher/Review/SubmissionReview.swift
@@ -29,7 +29,7 @@ struct SubmissionReview: View {
             Text("\(user.name)'s submission for \(submissionLink.assignment.name)")
                 .font(.title)
                 .fontWeight(.bold)
-            SubmissionRepoLink(assignmentName: submissionLink.assignment.name, orgPath: viewModel.currentCourse.organizationPath, userLogin: user.login)
+            SubmissionRepoLink(assignmentName: submissionLink.assignment.name, orgPath: viewModel.course.organizationPath, userLogin: user.login)
             SubmissionInfo(viewModel: viewModel, submissionLink: submissionLink)
             if submissionLink.hasSubmission{
                 if assignmentHasCriteriaList(){

--- a/Quickfeed/Views/Teacher/TeacherNavigationView.swift
+++ b/Quickfeed/Views/Teacher/TeacherNavigationView.swift
@@ -65,7 +65,7 @@ struct TeacherNavigationView: View {
                 })
             }
             
-            GithubLinkSection(orgPath: viewModel.currentCourse.organizationPath, userLogin: viewModel.user.login, isTeacher: true)
+            GithubLinkSection(orgPath: viewModel.course.organizationPath, userLogin: viewModel.user.login, isTeacher: true)
             
         }
         .onAppear(perform: {

--- a/Quickfeed/Views/User/Helpers/UserEnrollments.swift
+++ b/Quickfeed/Views/User/Helpers/UserEnrollments.swift
@@ -11,7 +11,7 @@ struct UserEnrollments: View {
     @State private var newEnrollments: Bool = false
     
     func sortCourseByCode() -> [Course] {
-        var courses = viewModel.getAllCourses()!
+        var courses = viewModel.getCourses()!
         courses.sort { $0.code < $1.code }
         return courses
     }


### PR DESCRIPTION
The viewModels have been organized into subcategories (same as in the gRPC Manager and Server Provider).  These subcategories have been marked with MARK: commands so that they are easy to find.

Further work before we can leave draft PR:
- Some of the methods in the viewModels can be a bit ugly.  Make viewmodel methods easier to read for others.